### PR TITLE
Converting tab characters to spaces

### DIFF
--- a/CampaignFunctionalExample/myapp.rb
+++ b/CampaignFunctionalExample/myapp.rb
@@ -17,162 +17,162 @@ require 'constantcontact'
 # Name this action according to your 
 # Constant Contact API Redirect URL, see config.yml
 get '/cc_callback' do
-		cnf = YAML::load(File.open('config/config.yml'))
+    cnf = YAML::load(File.open('config/config.yml'))
 
-		@oauth = ConstantContact::Auth::OAuth2.new(
-			:api_key => cnf['api_key'],
-			:api_secret => cnf['api_secret'],
-			:redirect_url => cnf['redirect_url']
-		)
+    @oauth = ConstantContact::Auth::OAuth2.new(
+      :api_key => cnf['api_key'],
+      :api_secret => cnf['api_secret'],
+      :redirect_url => cnf['redirect_url']
+    )
 
-		@error = params[:error]
-		@user = params[:username]
-		@code = params[:code]
+    @error = params[:error]
+    @user = params[:username]
+    @code = params[:code]
 
-		if @code
-			begin
-				response = @oauth.get_access_token(@code)
-				@token = response['access_token']
+    if @code
+      begin
+        response = @oauth.get_access_token(@code)
+        @token = response['access_token']
 
-				cc = ConstantContact::Api.new(cnf['api_key'])
+        cc = ConstantContact::Api.new(cnf['api_key'])
 
-				@campaign = {
-					'name'=> nil,
-					'subject' => nil,
-					'from_name' => nil,
-					'from_email' => nil,
-					'reply_to_email' => nil
-				}
+        @campaign = {
+          'name'=> nil,
+          'subject' => nil,
+          'from_name' => nil,
+          'from_email' => nil,
+          'reply_to_email' => nil
+        }
 
-				@message = {
-					'organization_name' => nil,
-					'address_line_1' => nil,
-					'address_line_2' => nil,
-					'address_line_3' => nil,
-					'city' => nil,
-					'state' => nil,
-					'international_state' => nil,
-					'country' => nil,
-					'postal_code' => nil
-				}
+        @message = {
+          'organization_name' => nil,
+          'address_line_1' => nil,
+          'address_line_2' => nil,
+          'address_line_3' => nil,
+          'city' => nil,
+          'state' => nil,
+          'international_state' => nil,
+          'country' => nil,
+          'postal_code' => nil
+        }
 
-				@schedule = {
-					'scheduled_date' => nil
-				}
+        @schedule = {
+          'scheduled_date' => nil
+        }
 
-				@lists = []
-				lists = cc.get_lists(@token)
-				if lists
-					lists.each do |list|
-						# Select the first list, by default
-						selected = list == lists.first
-						@lists << {
-							'id' => list.id,
-							'name' => list.name,
-							'selected' => selected
-						}
-					end
-				end
+        @lists = []
+        lists = cc.get_lists(@token)
+        if lists
+          lists.each do |list|
+            # Select the first list, by default
+            selected = list == lists.first
+            @lists << {
+              'id' => list.id,
+              'name' => list.name,
+              'selected' => selected
+            }
+          end
+        end
 
-				response = cc.get_verified_email_addresses(@token) rescue 'Resource not found'
-				if response
-					verified_email = response.first.email_address
-					@campaign['from_email'] = verified_email
-					@campaign['reply_to_email'] = verified_email
-				end
+        response = cc.get_verified_email_addresses(@token) rescue 'Resource not found'
+        if response
+          verified_email = response.first.email_address
+          @campaign['from_email'] = verified_email
+          @campaign['reply_to_email'] = verified_email
+        end
 
-			rescue => e
-				message = parse_exception(e)
-				@error = "An error occured when saving the campaign : " + message
-				#y e.backtrace
-			end
-			erb :campaign, :views_directory => 'views'
-		else
-			erb :callback, :views_directory => 'views'
-		end
+      rescue => e
+        message = parse_exception(e)
+        @error = "An error occured when saving the campaign : " + message
+        #y e.backtrace
+      end
+      erb :campaign, :views_directory => 'views'
+    else
+      erb :callback, :views_directory => 'views'
+    end
 end
 
 
 # Name this action according to your
 # Constant Contact API Redirect URL, see config.yml
 post '/cc_callback' do
-		cnf = YAML::load(File.open('config/config.yml'))
+    cnf = YAML::load(File.open('config/config.yml'))
 
-		@error = params[:error]
-		@user = params[:username]
-		@code = params[:code]
-		@token = params[:token]
+    @error = params[:error]
+    @user = params[:username]
+    @code = params[:code]
+    @token = params[:token]
 
-		if @code
-			cc = ConstantContact::Api.new(cnf['api_key'])
+    if @code
+      cc = ConstantContact::Api.new(cnf['api_key'])
 
-			@campaign = params[:campaign]
-			@message = params[:message]
-			@schedule = params[:schedule]
-			lists = params[:lists] || {}
-			lists['checkboxes'] = [] if lists['checkboxes'].blank?
+      @campaign = params[:campaign]
+      @message = params[:message]
+      @schedule = params[:schedule]
+      lists = params[:lists] || {}
+      lists['checkboxes'] = [] if lists['checkboxes'].blank?
 
-			@lists = []
-			if lists['ids']
-				lists['ids'].each do |key, list_id|
-					list_name = lists['names'][key]
-					selected = !(lists['checkboxes'].blank? || lists['checkboxes'][key].blank?)
-					@lists << {
-						'id' => list_id,
-						'name' => list_name,
-						'selected' => selected
-					}
-				end
-			end
+      @lists = []
+      if lists['ids']
+        lists['ids'].each do |key, list_id|
+          list_name = lists['names'][key]
+          selected = !(lists['checkboxes'].blank? || lists['checkboxes'][key].blank?)
+          @lists << {
+            'id' => list_id,
+            'name' => list_name,
+            'selected' => selected
+          }
+        end
+      end
 
-			begin
-				if @campaign
-					# Validate
-					raise 'Please fill in the name' if @campaign['name'].blank?
-					raise 'Please fill in the subject' if @campaign['subject'].blank?
-					raise 'Please fill in the from name' if @campaign['from_name'].blank?
-					raise 'Please fill in the from email address' if @campaign['from_email'].blank?
-					raise 'Please fill in the reply-to email address' if @campaign['reply_to_email'].blank?
-					raise 'Please fill in the greeting string' if @campaign['greeting_string'].blank?
-					raise 'Please fill in the text content' if @campaign['text_content'].blank?
-					raise 'Please fill in the email content' if @campaign['email_content'].blank?
-					raise 'Please select a list' if lists['checkboxes'].blank?
+      begin
+        if @campaign
+          # Validate
+          raise 'Please fill in the name' if @campaign['name'].blank?
+          raise 'Please fill in the subject' if @campaign['subject'].blank?
+          raise 'Please fill in the from name' if @campaign['from_name'].blank?
+          raise 'Please fill in the from email address' if @campaign['from_email'].blank?
+          raise 'Please fill in the reply-to email address' if @campaign['reply_to_email'].blank?
+          raise 'Please fill in the greeting string' if @campaign['greeting_string'].blank?
+          raise 'Please fill in the text content' if @campaign['text_content'].blank?
+          raise 'Please fill in the email content' if @campaign['email_content'].blank?
+          raise 'Please select a list' if lists['checkboxes'].blank?
 
-					if @message && !(@message['address_line_1'] || @message['city'] || @message['country']).blank?
-						@campaign['message_footer'] = @message
-					end
+          if @message && !(@message['address_line_1'] || @message['city'] || @message['country']).blank?
+            @campaign['message_footer'] = @message
+          end
 
-					@campaign['sent_to_contact_lists'] = []
-					lists['ids'].each do |key, list_id|
-						@campaign['sent_to_contact_lists'] << {:id => list_id} if lists['checkboxes'][key]
-					end
+          @campaign['sent_to_contact_lists'] = []
+          lists['ids'].each do |key, list_id|
+            @campaign['sent_to_contact_lists'] << {:id => list_id} if lists['checkboxes'][key]
+          end
 
-					campaign = ConstantContact::Components::Campaign.create(@campaign)
-					campaign = cc.add_email_campaign(@token, campaign)
-					if campaign && !@schedule['scheduled_date'].blank?
-						schedule = ConstantContact::Components::Schedule.create(@schedule)
-						cc.add_email_campaign_schedule(@token, campaign, schedule)
-					end
-					redirect '/cc_callback'
-				end
-			rescue => e
-				message = parse_exception(e)
-				@error = "An error occured when saving the campaign : " + message
-				#y e.backtrace
-			end
-			erb :campaign, :views_directory => 'views'
-		else
-			erb :callback, :views_directory => 'views'
-		end
+          campaign = ConstantContact::Components::Campaign.create(@campaign)
+          campaign = cc.add_email_campaign(@token, campaign)
+          if campaign && !@schedule['scheduled_date'].blank?
+            schedule = ConstantContact::Components::Schedule.create(@schedule)
+            cc.add_email_campaign_schedule(@token, campaign, schedule)
+          end
+          redirect '/cc_callback'
+        end
+      rescue => e
+        message = parse_exception(e)
+        @error = "An error occured when saving the campaign : " + message
+        #y e.backtrace
+      end
+      erb :campaign, :views_directory => 'views'
+    else
+      erb :callback, :views_directory => 'views'
+    end
 end
 
 
 def parse_exception(e)
-	if e.respond_to?(:response)
-		hash_error = JSON.parse(e.response)
-		message = hash_error.first['error_message']
-	else 
-		message = e.message
-	end
-	message.to_s
+  if e.respond_to?(:response)
+    hash_error = JSON.parse(e.response)
+    message = hash_error.first['error_message']
+  else
+    message = e.message
+  end
+  message.to_s
 end

--- a/ContactFunctionalExample/myapp.rb
+++ b/ContactFunctionalExample/myapp.rb
@@ -17,154 +17,154 @@ require 'constantcontact'
 # Name this action according to your 
 # Constant Contact API Redirect URL, see config.yml
 get '/cc_callback' do
-		cnf = YAML::load(File.open('config/config.yml'))
+    cnf = YAML::load(File.open('config/config.yml'))
 
-		@oauth = ConstantContact::Auth::OAuth2.new(
-			:api_key => cnf['api_key'],
-			:api_secret => cnf['api_secret'],
-			:redirect_url => cnf['redirect_url']
-		)
+    @oauth = ConstantContact::Auth::OAuth2.new(
+      :api_key => cnf['api_key'],
+      :api_secret => cnf['api_secret'],
+      :redirect_url => cnf['redirect_url']
+    )
 
-		@error = params[:error]
-		@user = params[:username]
-		@code = params[:code]
+    @error = params[:error]
+    @user = params[:username]
+    @code = params[:code]
 
-		if @code
-			begin
-				response = @oauth.get_access_token(@code)
-				@token = response['access_token']
+    if @code
+      begin
+        response = @oauth.get_access_token(@code)
+        @token = response['access_token']
 
-				cc = ConstantContact::Api.new(cnf['api_key'])
+        cc = ConstantContact::Api.new(cnf['api_key'])
 
-				@lists = []
-				lists = cc.get_lists(@token)
-				if lists
-					lists.each do |list|
-						# Select the first list, by default
-						selected = list == lists.first
-						@lists << {
-							'id' => list.id,
-							'name' => list.name,
-							'selected' => selected
-						}
-					end
-				end
+        @lists = []
+        lists = cc.get_lists(@token)
+        if lists
+          lists.each do |list|
+            # Select the first list, by default
+            selected = list == lists.first
+            @lists << {
+              'id' => list.id,
+              'name' => list.name,
+              'selected' => selected
+            }
+          end
+        end
 
-				@contact = {
-					'first_name'=> nil,
-					'last_name' => nil,
-					'middle_name' => nil
-				}
+        @contact = {
+          'first_name'=> nil,
+          'last_name' => nil,
+          'middle_name' => nil
+        }
 
-				@email = {
-					'email_address' => nil
-				}
+        @email = {
+          'email_address' => nil
+        }
 
-				@address = {
-					'line1' => nil,
-					'line2' => nil,
-					'line3' => nil,
-					'city' => nil,
-					'state_code' => nil,
-					'country_code' => nil,
-					'postal_code' => nil,
-					'sub_postal_code' => nil
-				}
-			rescue => e
-				message = parse_exception(e)
-				@error = "An error occured when saving the contact : " + message
-				#y e.backtrace
-			end
-			erb :contact, :views_directory => 'views'
-		else
-			erb :callback, :views_directory => 'views'
-		end
+        @address = {
+          'line1' => nil,
+          'line2' => nil,
+          'line3' => nil,
+          'city' => nil,
+          'state_code' => nil,
+          'country_code' => nil,
+          'postal_code' => nil,
+          'sub_postal_code' => nil
+        }
+      rescue => e
+        message = parse_exception(e)
+        @error = "An error occured when saving the contact : " + message
+        #y e.backtrace
+      end
+      erb :contact, :views_directory => 'views'
+    else
+      erb :callback, :views_directory => 'views'
+    end
 end
 
 
 # Name this action according to your
 # Constant Contact API Redirect URL, see config.yml
 post '/cc_callback' do
-		cnf = YAML::load(File.open('config/config.yml'))
+    cnf = YAML::load(File.open('config/config.yml'))
 
-		@error = params[:error]
-		@user = params[:username]
-		@code = params[:code]
-		@token = params[:token]
+    @error = params[:error]
+    @user = params[:username]
+    @code = params[:code]
+    @token = params[:token]
 
-		if @code
-			cc = ConstantContact::Api.new(cnf['api_key'])
+    if @code
+      cc = ConstantContact::Api.new(cnf['api_key'])
 
-			@contact = params[:contact]
-			@email = params[:email]
-			@address = params[:address]
-			lists = params[:lists] || {}
-			lists['checkboxes'] = [] if lists['checkboxes'].blank?
+      @contact = params[:contact]
+      @email = params[:email]
+      @address = params[:address]
+      lists = params[:lists] || {}
+      lists['checkboxes'] = [] if lists['checkboxes'].blank?
 
-			@lists = []
-			if lists['ids']
-				lists['ids'].each do |key, list_id|
-					list_name = lists['names'][key]
-					selected = !(lists['checkboxes'].blank? || lists['checkboxes'][key].blank?)
-					@lists << {
-						'id' => list_id,
-						'name' => list_name,
-						'selected' => selected
-					}
-				end
-			end
+      @lists = []
+      if lists['ids']
+        lists['ids'].each do |key, list_id|
+          list_name = lists['names'][key]
+          selected = !(lists['checkboxes'].blank? || lists['checkboxes'][key].blank?)
+          @lists << {
+            'id' => list_id,
+            'name' => list_name,
+            'selected' => selected
+          }
+        end
+      end
 
-			begin
-				if @contact
-					# Validate
-					raise 'Please fill in the first name' if @contact['first_name'].blank?
-					raise 'Please fill in the last name' if @contact['last_name'].blank?
-					raise 'Please fill in the email' if @email['email_address'].blank?
-					raise 'Please select a list' if lists['checkboxes'].blank?
+      begin
+        if @contact
+          # Validate
+          raise 'Please fill in the first name' if @contact['first_name'].blank?
+          raise 'Please fill in the last name' if @contact['last_name'].blank?
+          raise 'Please fill in the email' if @email['email_address'].blank?
+          raise 'Please select a list' if lists['checkboxes'].blank?
 
-					@contact['email_addresses'] = []
-					@contact['addresses'] = []
-					@contact['lists'] = []
+          @contact['email_addresses'] = []
+          @contact['addresses'] = []
+          @contact['lists'] = []
 
-					if @email['email_address']
-						@contact['email_addresses'] << @email
-					end
+          if @email['email_address']
+            @contact['email_addresses'] << @email
+          end
 
-					if @address
-						@contact['addresses'] << @address
-					end
+          if @address
+            @contact['addresses'] << @address
+          end
 
-					lists['ids'].each do |key, list_id|
-						@contact['lists'] << {:id => list_id} if lists['checkboxes'][key]
-					end
+          lists['ids'].each do |key, list_id|
+            @contact['lists'] << {:id => list_id} if lists['checkboxes'][key]
+          end
 
-					response = cc.get_contact_by_email(@token, @email['email_address']) rescue 'Resource not found'
-					contact = ConstantContact::Components::Contact.create(@contact)
-					if response && response.respond_to?(:results)
-						contact.id = response.results.first.id.to_s
-						cc.update_contact(@token, contact)
-					else
-						cc.add_contact(@token, contact)
-					end
-					redirect '/cc_callback'
-				end
-			rescue => e
-				message = parse_exception(e)
-				@error = "An error occured when saving the contact : " + message
-				#y e.backtrace
-			end
-			erb :contact, :views_directory => 'views'
-		else
-			erb :callback, :views_directory => 'views'
-		end
+          response = cc.get_contact_by_email(@token, @email['email_address']) rescue 'Resource not found'
+          contact = ConstantContact::Components::Contact.create(@contact)
+          if response && response.respond_to?(:results)
+            contact.id = response.results.first.id.to_s
+            cc.update_contact(@token, contact)
+          else
+            cc.add_contact(@token, contact)
+          end
+          redirect '/cc_callback'
+        end
+      rescue => e
+        message = parse_exception(e)
+        @error = "An error occured when saving the contact : " + message
+        #y e.backtrace
+      end
+      erb :contact, :views_directory => 'views'
+    else
+      erb :callback, :views_directory => 'views'
+    end
 end
 
 def parse_exception(e)
-	if e.respond_to?(:response)
-		hash_error = JSON.parse(e.response)
-		message = hash_error.first['error_message']
-	else 
-		message = e.message
-	end
-	message.to_s
+  if e.respond_to?(:response)
+    hash_error = JSON.parse(e.response)
+    message = hash_error.first['error_message']
+  else
+    message = e.message
+  end
+  message.to_s
 end

--- a/lib/constantcontact.rb
+++ b/lib/constantcontact.rb
@@ -13,63 +13,63 @@ require 'cgi/session/pstore'
 
 
 module ConstantContact
-	autoload :Api, "constantcontact/api"
+  autoload :Api, "constantcontact/api"
 
-	module Auth
-		autoload :OAuth2, "constantcontact/auth/oauth2"
-		autoload :Session, "constantcontact/auth/session_data_store"
-	end
+  module Auth
+    autoload :OAuth2, "constantcontact/auth/oauth2"
+    autoload :Session, "constantcontact/auth/session_data_store"
+  end
 
-	module Components
-		autoload :Component, "constantcontact/components/component"
-		autoload :ResultSet, "constantcontact/components/result_set"
-		autoload :Activity, "constantcontact/components/activities/activity"
-		autoload :ActivityError, "constantcontact/components/activities/activity_error"
-		autoload :AddContacts, "constantcontact/components/activities/add_contacts"
-		autoload :AddContactsImportData, "constantcontact/components/activities/add_contacts_import_data"
-		autoload :ExportContacts, "constantcontact/components/activities/export_contacts"
-		autoload :Address, "constantcontact/components/contacts/address"
-		autoload :Contact, "constantcontact/components/contacts/contact"
-		autoload :ContactList, "constantcontact/components/contacts/contact_list"
-		autoload :CustomField, "constantcontact/components/contacts/custom_field"
-		autoload :EmailAddress, "constantcontact/components/contacts/email_address"
-		autoload :Note, "constantcontact/components/contacts/note"
-		autoload :ClickThroughDetails, "constantcontact/components/email_marketing/click_through_details"
-		autoload :Campaign, "constantcontact/components/email_marketing/campaign"
-		autoload :MessageFooter, "constantcontact/components/email_marketing/message_footer"
-		autoload :Schedule, "constantcontact/components/email_marketing/schedule"
-		autoload :TestSend, "constantcontact/components/email_marketing/test_send"
-		autoload :BounceActivity, "constantcontact/components/tracking/bounce_activity"
-		autoload :ClickActivity, "constantcontact/components/tracking/click_activity"
-		autoload :ForwardActivity, "constantcontact/components/tracking/forward_activity"
-		autoload :OpenActivity, "constantcontact/components/tracking/open_activity"
-		autoload :OptOutActivity, "constantcontact/components/tracking/opt_out_activity"
-		autoload :SendActivity, "constantcontact/components/tracking/send_activity"
-		autoload :TrackingActivity, "constantcontact/components/tracking/tracking_activity"
-		autoload :TrackingSummary, "constantcontact/components/tracking/tracking_summary"
-		autoload :VerifiedEmailAddress, "constantcontact/components/account/verified_email_address"
-	end
+  module Components
+    autoload :Component, "constantcontact/components/component"
+    autoload :ResultSet, "constantcontact/components/result_set"
+    autoload :Activity, "constantcontact/components/activities/activity"
+    autoload :ActivityError, "constantcontact/components/activities/activity_error"
+    autoload :AddContacts, "constantcontact/components/activities/add_contacts"
+    autoload :AddContactsImportData, "constantcontact/components/activities/add_contacts_import_data"
+    autoload :ExportContacts, "constantcontact/components/activities/export_contacts"
+    autoload :Address, "constantcontact/components/contacts/address"
+    autoload :Contact, "constantcontact/components/contacts/contact"
+    autoload :ContactList, "constantcontact/components/contacts/contact_list"
+    autoload :CustomField, "constantcontact/components/contacts/custom_field"
+    autoload :EmailAddress, "constantcontact/components/contacts/email_address"
+    autoload :Note, "constantcontact/components/contacts/note"
+    autoload :ClickThroughDetails, "constantcontact/components/email_marketing/click_through_details"
+    autoload :Campaign, "constantcontact/components/email_marketing/campaign"
+    autoload :MessageFooter, "constantcontact/components/email_marketing/message_footer"
+    autoload :Schedule, "constantcontact/components/email_marketing/schedule"
+    autoload :TestSend, "constantcontact/components/email_marketing/test_send"
+    autoload :BounceActivity, "constantcontact/components/tracking/bounce_activity"
+    autoload :ClickActivity, "constantcontact/components/tracking/click_activity"
+    autoload :ForwardActivity, "constantcontact/components/tracking/forward_activity"
+    autoload :OpenActivity, "constantcontact/components/tracking/open_activity"
+    autoload :OptOutActivity, "constantcontact/components/tracking/opt_out_activity"
+    autoload :SendActivity, "constantcontact/components/tracking/send_activity"
+    autoload :TrackingActivity, "constantcontact/components/tracking/tracking_activity"
+    autoload :TrackingSummary, "constantcontact/components/tracking/tracking_summary"
+    autoload :VerifiedEmailAddress, "constantcontact/components/account/verified_email_address"
+  end
 
-	module Exceptions
-		autoload :CtctException, "constantcontact/exceptions/ctct_exception"
-		autoload :IllegalArgumentException, "constantcontact/exceptions/illegal_argument_exception"
-		autoload :OAuth2Exception, "constantcontact/exceptions/oauth2_exception"
-	end
+  module Exceptions
+    autoload :CtctException, "constantcontact/exceptions/ctct_exception"
+    autoload :IllegalArgumentException, "constantcontact/exceptions/illegal_argument_exception"
+    autoload :OAuth2Exception, "constantcontact/exceptions/oauth2_exception"
+  end
 
-	module Services
-		autoload :BaseService, "constantcontact/services/base_service"
-		autoload :ActivityService, "constantcontact/services/activity_service"
-		autoload :CampaignScheduleService, "constantcontact/services/campaign_schedule_service"
-		autoload :CampaignTrackingService, "constantcontact/services/campaign_tracking_service"
-		autoload :ContactService, "constantcontact/services/contact_service"
-		autoload :ContactTrackingService, "constantcontact/services/contact_tracking_service"
-		autoload :EmailMarketingService, "constantcontact/services/email_marketing_service"
-		autoload :ListService, "constantcontact/services/list_service"
-		autoload :AccountService, "constantcontact/services/account_service"
-	end
+  module Services
+    autoload :BaseService, "constantcontact/services/base_service"
+    autoload :ActivityService, "constantcontact/services/activity_service"
+    autoload :CampaignScheduleService, "constantcontact/services/campaign_schedule_service"
+    autoload :CampaignTrackingService, "constantcontact/services/campaign_tracking_service"
+    autoload :ContactService, "constantcontact/services/contact_service"
+    autoload :ContactTrackingService, "constantcontact/services/contact_tracking_service"
+    autoload :EmailMarketingService, "constantcontact/services/email_marketing_service"
+    autoload :ListService, "constantcontact/services/list_service"
+    autoload :AccountService, "constantcontact/services/account_service"
+  end
 
-	module Util
-		autoload :Config, "constantcontact/util/config"
-		autoload :Helpers, "constantcontact/util/helpers"
-	end
+  module Util
+    autoload :Config, "constantcontact/util/config"
+    autoload :Helpers, "constantcontact/util/helpers"
+  end
 end

--- a/lib/constantcontact/api.rb
+++ b/lib/constantcontact/api.rb
@@ -5,537 +5,537 @@
 # Copyright (c) 2013 Constant Contact. All rights reserved.
 
 module ConstantContact
-	class Api
-
-		# Class constructor
-		# @param [String] api_key - Constant Contact API Key
-		# @return
-		def initialize(api_key)
-			Services::BaseService.api_key = api_key
-		end
-
-
-		# Get verified addresses for the account
-		# @param [String] access_token - Valid access token
-		# @return [Array<VerifiedEmailAddress>] an array of email addresses
-		def get_verified_email_addresses(access_token)
-			Services::AccountService.get_verified_email_addresses(access_token)
-		end
-
-
-		# Get a set of contacts
-		# @param [String] access_token - Valid access token
-		# @param [Integer] param - denotes the number of results per set, limited to 50, 
-		# or a next parameter provided from a previous call
-		# @return [ResultSet<Contact>] a ResultSet of Contacts
-		def get_contacts(access_token, param = nil)
-			param = determine_param(param)
-			Services::ContactService.get_contacts(access_token, param)
-		end
-
-
-		# Get an individual contact
-		# @param [String] access_token - Valid access token
-		# @param [Integer] contact_id - Id of the contact to retrieve
-		# @return [Contact]
-		def get_contact(access_token, contact_id)
-			Services::ContactService.get_contact(access_token, contact_id)
-		end
-
-
-		# Get contacts with a specified email eaddress
-		# @param [String] access_token - Constant Contact OAuth2 access token
-		# @param [String] email - contact email address to search for
-		# @return [ResultSet<Contact>] a ResultSet of Contacts
-		def get_contact_by_email(access_token, email)
-			Services::ContactService.get_contacts(access_token, {'email' => email})
-		end
-
-
-		# Add a new contact to an account
-		# @param [String] access_token - Valid access token
-		# @param [Contact] contact - Contact to add
-		# @param [Boolean] action_by_visitor - if the action is being taken by the visitor
-		# @return [Contact]
-		def add_contact(access_token, contact, action_by_visitor = false)
-			Services::ContactService.add_contact(access_token, contact, action_by_visitor)
-		end
-
-
-		# Sets an individual contact to 'REMOVED' status
-		# @param [String] access_token - Valid access token
-		# @param [Mixed] contact - Either a Contact id or the Contact itself
-		# @raise [IllegalArgumentException] If contact is not an integer or a Contact object
-		# @return [Boolean]
-		def delete_contact(access_token, contact)
-			contact_id = get_argument_id(contact, 'Contact')
-			Services::ContactService.delete_contact(access_token, contact_id)
-		end
-
-
-		# Delete a contact from all contact lists
-		# @param [String] access_token - Constant Contact OAuth2 access token
-		# @param [Mixed] contact - Contact id or the Contact object itself
-		# @raise [IllegalArgumentException] If contact is not an integer or a Contact object
-		# @return [Boolean]
-		def delete_contact_from_lists(access_token, contact)
-			contact_id = get_argument_id(contact, 'Contact')
-			Services::ContactService.delete_contact_from_lists(access_token, contact_id)
-		end
-
-
-		# Delete a contact from all contact lists
-		# @param [String] access_token - Constant Contact OAuth2 access token
-		# @param [Mixed] contact - Contact id or a Contact object
-		# @param [Mixed] list - ContactList id or a ContactList object
-		# @raise [IllegalArgumentException] If contact is not an integer or a Contact object
-		# @return [Boolean]
-		def delete_contact_from_list(access_token, contact, list)
-			contact_id = get_argument_id(contact, 'Contact')
-			list_id = get_argument_id(list, 'ContactList')
-			Services::ContactService.delete_contact_from_list(access_token, contact_id, list_id)
-		end
-
-
-		# Update an individual contact
-		# @param [String] access_token - Valid access token
-		# @param [Contact] contact - Contact to update
-		# @param [Boolean] action_by_visitor - if the action is being taken by the visitor
-		# @return [Contact]
-		def update_contact(access_token, contact, action_by_visitor = false)
-			Services::ContactService.update_contact(access_token, contact, action_by_visitor)
-		end
-
+  class Api
+
+    # Class constructor
+    # @param [String] api_key - Constant Contact API Key
+    # @return
+    def initialize(api_key)
+      Services::BaseService.api_key = api_key
+    end
+
+
+    # Get verified addresses for the account
+    # @param [String] access_token - Valid access token
+    # @return [Array<VerifiedEmailAddress>] an array of email addresses
+    def get_verified_email_addresses(access_token)
+      Services::AccountService.get_verified_email_addresses(access_token)
+    end
+
+
+    # Get a set of contacts
+    # @param [String] access_token - Valid access token
+    # @param [Integer] param - denotes the number of results per set, limited to 50,
+    # or a next parameter provided from a previous call
+    # @return [ResultSet<Contact>] a ResultSet of Contacts
+    def get_contacts(access_token, param = nil)
+      param = determine_param(param)
+      Services::ContactService.get_contacts(access_token, param)
+    end
+
+
+    # Get an individual contact
+    # @param [String] access_token - Valid access token
+    # @param [Integer] contact_id - Id of the contact to retrieve
+    # @return [Contact]
+    def get_contact(access_token, contact_id)
+      Services::ContactService.get_contact(access_token, contact_id)
+    end
+
+
+    # Get contacts with a specified email eaddress
+    # @param [String] access_token - Constant Contact OAuth2 access token
+    # @param [String] email - contact email address to search for
+    # @return [ResultSet<Contact>] a ResultSet of Contacts
+    def get_contact_by_email(access_token, email)
+      Services::ContactService.get_contacts(access_token, {'email' => email})
+    end
+
+
+    # Add a new contact to an account
+    # @param [String] access_token - Valid access token
+    # @param [Contact] contact - Contact to add
+    # @param [Boolean] action_by_visitor - if the action is being taken by the visitor
+    # @return [Contact]
+    def add_contact(access_token, contact, action_by_visitor = false)
+      Services::ContactService.add_contact(access_token, contact, action_by_visitor)
+    end
+
+
+    # Sets an individual contact to 'REMOVED' status
+    # @param [String] access_token - Valid access token
+    # @param [Mixed] contact - Either a Contact id or the Contact itself
+    # @raise [IllegalArgumentException] If contact is not an integer or a Contact object
+    # @return [Boolean]
+    def delete_contact(access_token, contact)
+      contact_id = get_argument_id(contact, 'Contact')
+      Services::ContactService.delete_contact(access_token, contact_id)
+    end
+
+
+    # Delete a contact from all contact lists
+    # @param [String] access_token - Constant Contact OAuth2 access token
+    # @param [Mixed] contact - Contact id or the Contact object itself
+    # @raise [IllegalArgumentException] If contact is not an integer or a Contact object
+    # @return [Boolean]
+    def delete_contact_from_lists(access_token, contact)
+      contact_id = get_argument_id(contact, 'Contact')
+      Services::ContactService.delete_contact_from_lists(access_token, contact_id)
+    end
+
+
+    # Delete a contact from all contact lists
+    # @param [String] access_token - Constant Contact OAuth2 access token
+    # @param [Mixed] contact - Contact id or a Contact object
+    # @param [Mixed] list - ContactList id or a ContactList object
+    # @raise [IllegalArgumentException] If contact is not an integer or a Contact object
+    # @return [Boolean]
+    def delete_contact_from_list(access_token, contact, list)
+      contact_id = get_argument_id(contact, 'Contact')
+      list_id = get_argument_id(list, 'ContactList')
+      Services::ContactService.delete_contact_from_list(access_token, contact_id, list_id)
+    end
+
+
+    # Update an individual contact
+    # @param [String] access_token - Valid access token
+    # @param [Contact] contact - Contact to update
+    # @param [Boolean] action_by_visitor - if the action is being taken by the visitor
+    # @return [Contact]
+    def update_contact(access_token, contact, action_by_visitor = false)
+      Services::ContactService.update_contact(access_token, contact, action_by_visitor)
+    end
+
 
-		# Get lists
-		# @param [String] access_token - Valid access token
-		# @return [Array<ContactList>] Array of ContactList objects
-		def get_lists(access_token)
-			Services::ListService.get_lists(access_token)
-		end
-
-
-		# Get an individual list
-		# @param [String] access_token - Valid access token
-		# @param [Integer] list_id - Id of the list to retrieve
-		# @return [ContactList]
-		def get_list(access_token, list_id)
-			Services::ListService.get_list(access_token, list_id)
-		end
-
-
-		# Add a new list to an account
-		# @param [String] access_token - Valid access token
-		# @param [ContactList] list - List to add
-		# @return [ContactList]
-		def add_list(access_token, list)
-			Services::ListService.add_list(access_token, list)
-		end
-
-
-		# Update a contact list
-		# @param [String] access_token - Valid access token
-		# @param [ContactList] list - ContactList to update
-		# @return [ContactList]
-		def update_list(access_token, list)
-			Services::ListService.update_list(access_token, list)
-		end
-
-
-		# Get contact that belong to a specific list
-		# @param [String] access_token - Constant Contact OAuth2 access token
-		# @param [Mixed] list - Integer id of the list or ContactList object
-		# @raise [IllegalArgumentException] If contact is not an integer or contact
-		# @return [Array<Contact>] An array of contacts
-		def get_contacts_from_list(access_token, list)
-			list_id = get_argument_id(list, 'ContactList')
-			Services::ListService.get_contacts_from_list(access_token, list_id)
-		end
-
-
-		# Get a set of campaigns
-		# @param [String] access_token - Constant Contact OAuth2 access token
-		# @param [String] param - denotes the number of results per set, limited to 50, or a next parameter provided
-		# from a previous call
-		# @return [ResultSet<Campaign>]
-		def get_email_campaigns(access_token, param = nil)
-			param = determine_param(param)
-			Services::EmailMarketingService.get_campaigns(access_token, param)
-		end
-
-
-		# Get an individual campaign
-		# @param [String] access_token - Constant Contact OAuth2 access token
-		# @param [Integer] campaign_id - Valid campaign id
-		# @return [Campaign]
-		def get_email_campaign(access_token, campaign_id)
-			Services::EmailMarketingService.get_campaign(access_token, campaign_id)
-		end
-
-
-		# Delete an individual campaign
-		# @param [String] access_token - Constant Contact OAuth2 access token
-		# @param [Mixed] campaign - Id of a campaign or a Campaign object
-		# @raise IllegalArgumentException - if a Campaign object or campaign id is not passed
-		# @return [Boolean]
-		def delete_email_campaign(access_token, campaign)
-			campaign_id = get_argument_id(campaign, 'Campaign')
-			Services::EmailMarketingService.delete_campaign(access_token, campaign_id)
-		end
-
-
-		# Create a new campaign
-		# @param [String] access_token - Constant Contact OAuth2 access token
-		# @param [Campaign] campaign - Campaign to be created
-		# @return [Campaign] - created campaign
-		def add_email_campaign(access_token, campaign)
-			Services::EmailMarketingService.add_campaign(access_token, campaign)
-		end
-
-
-		# Update a specific campaign
-		# @param [String] access_token - Constant Contact OAuth2 access token
-		# @param [Campaign] campaign - Campaign to be updated
-		# @return [Campaign] - updated campaign
-		def update_email_campaign(access_token, campaign)
-			Services::EmailMarketingService.update_campaign(access_token, campaign)
-		end
-
-
-		# Schedule a campaign to be sent
-		# @param [String] access_token - Constant Contact OAuth2 access token
-		# @param [Mixed] campaign - Id of a campaign or a Campaign object
-		# @param [Schedule] schedule - Schedule to be associated with the provided campaign
-		# @return [Campaign] - updated campaign
-		def add_email_campaign_schedule(access_token, campaign, schedule)
-			campaign_id = get_argument_id(campaign, 'Campaign')
-			Services::CampaignScheduleService.add_schedule(access_token, campaign_id, schedule)
-		end
-
-
-		# Get an array of schedules associated with a given campaign
-		# @param [String] access_token - Constant Contact OAuth2 access token
-		# @param [Mixed] campaign - Campaign id or Campaign object itself
-		# @return [Array<Schedule>]
-		def get_email_campaign_schedules(access_token, campaign)
-			campaign_id = get_argument_id(campaign, 'Campaign')
-			Services::CampaignScheduleService.get_schedules(access_token, campaign_id)
-		end
-
-
-		# Get a specific schedule associated with a given campaign
-		# @param [String] access_token - Constant Contact OAuth2 access token
-		# @param [Mixed] campaign - Campaign id or Campaign object itself
-		# @param [Mixed] schedule - Schedule id or Schedule object itself
-		# @raise IllegalArgumentException
-		# @return [Schedule]
-		def get_email_campaign_schedule(access_token, campaign, schedule)
-			campaign_id = get_argument_id(campaign, 'Campaign')
-			schedule_id = get_argument_id(schedule, 'Schedule')
-			Services::CampaignScheduleService.get_schedule(access_token, campaign_id, schedule_id)
-		end
-
-
-		# Update a specific schedule associated with a given campaign
-		# @param [String] access_token - Constant Contact OAuth2 access token
-		# @param [Mixed] campaign - Campaign id or Campaign object itself
-		# @param [Schedule] schedule - Schedule to be updated
-		# @return [Schedule]
-		def update_email_campaign_schedule(access_token, campaign, schedule)
-			campaign_id = get_argument_id(campaign, 'Campaign')
-			Services::CampaignScheduleService.update_schedule(access_token, campaign_id, schedule)
-		end
-
-
-		# Delete a specific schedule associated with a given campaign
-		# @param [String] access_token - Constant Contact OAuth2 access token
-		# @param [Mixed] campaign - Campaign id or Campaign object itself
-		# @param [Mixed] schedule - Schedule id or Schedule object itself
-		# @raise IllegalArgumentException
-		# @return [Boolean]
-		def delete_email_campaign_schedule(access_token, campaign, schedule)
-			campaign_id = get_argument_id(campaign, 'Campaign')
-			schedule_id = get_argument_id(schedule, 'Schedule')
-			Services::CampaignScheduleService.delete_schedule(access_token, campaign_id, schedule_id)
-		end
-
-
-		# Send a test send of a campaign
-		# @param [String] access_token - Constant Contact OAuth2 access token
-		# @param [Mixed] campaign - Campaign id or Campaign object itself
-		# @param [TestSend] test_send - test send details
-		# @return [TestSend]
-		def send_email_campaign_test(access_token, campaign, test_send)
-			campaign_id = get_argument_id(campaign, 'Campaign')
-			Services::CampaignScheduleService.send_test(access_token, campaign_id, test_send)
-		end
-
-
-		# Get sends for a campaign
-		# @param [String] access_token - Constant Contact OAuth2 access token
-		# @param [Mixed] campaign - Campaign id or Campaign object itself
-		# @param [String] param - next value returned from a previous request (used in pagination)
-		# @return [ResultSet<SendActivity>]
-		def get_email_campaign_sends(access_token, campaign, param = nil)
-			campaign_id = get_argument_id(campaign, 'Campaign')
-			param = determine_param(param)
-			Services::CampaignTrackingService.get_sends(access_token, campaign_id, param)
-		end
-
-
-		# Get bounces for a campaign
-		# @param [String] access_token - Constant Contact OAuth2 access token
-		# @param [Mixed] campaign  - Campaign id or Campaign object itself
-		# @param [Mixed] param - either the next link from a previous request, or a limit or restrict the page size of
-		# an initial request
-		# @return [ResultSet<BounceActivity>]
-		def get_email_campaign_bounces(access_token, campaign, param = nil)
-			campaign_id = get_argument_id(campaign, 'Campaign')
-			param = determine_param(param)
-			Services::CampaignTrackingService.get_bounces(access_token, campaign_id, param)
-		end
-
-
-		# Get clicks for a campaign
-		# @param [String] access_token - Constant Contact OAuth2 access token
-		# @param [Mixed] campaign - Campaign id or Campaign object itself
-		# @param [Mixed] param - either the next link from a previous request, or a limit or restrict the page size of
-		# an initial request
-		# @return [ResultSet<ClickActivity>]
-		def get_email_campaign_clicks(access_token, campaign, param = nil)
-			campaign_id = get_argument_id(campaign, 'Campaign')
-			param = determine_param(param)
-			Services::CampaignTrackingService.get_clicks(access_token, campaign_id, param)
-		end
-
-
-		# Get opens for a campaign
-		# @param [String] access_token - Constant Contact OAuth2 access token
-		# @param [Mixed] campaign  - Campaign id or Campaign object itself
-		# @param [Mixed] param - either the next link from a previous request, or a limit or restrict the page size of
-		# an initial request
-		# @return [ResultSet<OpenActivity>]
-		def get_email_campaign_opens(access_token, campaign, param = nil)
-			campaign_id = get_argument_id(campaign, 'Campaign')
-			param = determine_param(param)
-			Services::CampaignTrackingService.get_opens(access_token, campaign_id, param)
-		end
-
-
-		# Get forwards for a campaign
-		# @param [String] access_token - Constant Contact OAuth2 access token
-		# @param [Mixed] campaign - Campaign id or Campaign object itself
-		# @param [Mixed] param - either the next link from a previous request, or a limit or restrict the page size of
-		# an initial request
-		# @return [ResultSet<ForwardActivity>]
-		def get_email_campaign_forwards(access_token, campaign, param = nil)
-			campaign_id = get_argument_id(campaign, 'Campaign')
-			param = determine_param(param)
-			Services::CampaignTrackingService.get_forwards(access_token, campaign_id, param)
-		end
-
-
-		# Get unsubscribes for a campaign
-		# @param [String] access_token - Constant Contact OAuth2 access token
-		# @param [Mixed] campaign - Campaign id or Campaign object itself
-		# @param [Mixed] param - either the next link from a previous request, or a limit or restrict the page size of
-		# an initial request
-		# @return [ResultSet<UnsubscribeActivity>] - Containing a results array of UnsubscribeActivity
-		def get_email_campaign_unsubscribes(access_token, campaign, param = nil)
-			campaign_id = get_argument_id(campaign, 'Campaign')
-			param = determine_param(param)
-			Services::CampaignTrackingService.get_unsubscribes(access_token, campaign_id, param)
-		end
-
-
-		# Get a reporting summary for a campaign
-		# @param [String] access_token - Constant Contact OAuth2 access token
-		# @param [Mixed] campaign  - Campaign id or Campaign object itself
-		# @return [TrackingSummary]
-		def get_email_campaign_summary_report(access_token, campaign)
-			campaign_id = get_argument_id(campaign, 'Campaign')
-			Services::CampaignTrackingService.get_summary(access_token, campaign_id)
-		end
-
-
-		# Get sends for a Contact
-		# @param [String] access_token - Constant Contact OAuth2 access token
-		# @param [Mixed] contact - Contact id or Contact object itself
-		# @param [Mixed] param - either the next link from a previous request, or a limit or restrict the page size of
-		# an initial request
-		# @return [ResultSet<SendActivity>]
-		def get_contact_sends(access_token, contact, param = nil)
-			contact_id = get_argument_id(contact, 'Contact')
-			Services::ContactTrackingService.get_sends(access_token, contact_id, param)
-		end
-
-
-		# Get bounces for a Contact
-		# @param [String] access_token - Constant Contact OAuth2 access token
-		# @param [Mixed] contact - Contact id or Contact object itself
-		# @param [Mixed] param - either the next link from a previous request, or a limit or restrict the page size of
-		# an initial request
-		# @return [ResultSet<BounceActivity>]
-		def get_contact_bounces(access_token, contact, param = nil)
-			contact_id = get_argument_id(contact, 'Contact')
-			Services::ContactTrackingService.get_bounces(access_token, contact_id, param)
-		end
-
-
-		# Get clicks for a Contact
-		# @param [String] access_token - Constant Contact OAuth2 access token
-		# @param [Mixed] contact - Contact id or Contact object itself
-		# @param [Mixed] param - either the next link from a previous request, or a limit or restrict the page size of
-		# an initial request
-		# @return [ResultSet<ClickActivity>]
-		def get_contact_clicks(access_token, contact, param = nil)
-			contact_id = get_argument_id(contact, 'Contact')
-			param = determine_param(param)
-			Services::ContactTrackingService.get_clicks(access_token, contact_id, param)
-		end
-
-
-		# Get opens for a Contact
-		# @param [String] access_token - Constant Contact OAuth2 access token
-		# @param [Mixed] contact  - Contact id or Contact object itself
-		# @param [Mixed] param - either the next link from a previous request, or a limit or restrict the page size of
-		# an initial request
-		# @return [ResultSet<OpenActivity>]
-		def get_contact_opens(access_token, contact, param = nil)
-			contact_id = get_argument_id(contact, 'Contact')
-			param = determine_param(param)
-			Services::ContactTrackingService.get_opens(access_token, contact_id, param)
-		end
-
-
-		# Get forwards for a Contact
-		# @param [String] access_token - Constant Contact OAuth2 access token
-		# @param [Mixed] contact  - Contact id or Contact object itself
-		# @param [Mixed] param - either the next link from a previous request, or a limit or restrict the page size of
-		# an initial request
-		# @return [ResultSet<ForwardActivity>]
-		def get_contact_forwards(access_token, contact, param = nil)
-			contact_id = get_argument_id(contact, 'Contact')
-			param = determine_param(param)
-			Services::ContactTrackingService.get_forwards(access_token, contact_id, param)
-		end
-
-
-		# Get unsubscribes for a Contact
-		# @param [String] access_token - Constant Contact OAuth2 access token
-		# @param [Mixed] contact - Contact id or Contact object itself
-		# @param [Hash] param - either the next link from a previous request, or a limit or restrict the page size of
-		# an initial request
-		# @return [UnsubscribeActivity] - Containing a results array of UnsubscribeActivity
-		def get_contact_unsubscribes(access_token, contact, param = nil)
-			contact_id = get_argument_id(contact, 'Contact')
-			param = determine_param(param)
-			Services::ContactTrackingService.get_unsubscribes(access_token, contact_id, param)
-		end
-
-
-		# Get a reporting summary for a Contact
-		# @param [String] access_token - Constant Contact OAuth2 access token
-		# @param [Mixed] contact - Contact id or Contact object itself
-		# @return [TrackingSummary]
-		def get_contact_summary_report(access_token, contact)
-			contact_id = get_argument_id(contact, 'Contact')
-			Services::ContactTrackingService.get_summary(access_token, contact_id)
-		end
-
-
-		# Get an array of activities
-		# @param [String] access_token - Constant Contact OAuth2 access token
-		# @return [Array<Activity>]
-		def get_activities(access_token)
-			Services::ActivityService.get_activities(access_token)
-		end
-
-
-		# Get a single activity by id
-		# @param [String] access_token - Constant Contact OAuth2 access token
-		# @param [String] activity_id - Activity id
-		# @return [Activity]
-		def get_activity(access_token, activity_id)
-			Services::ActivityService.get_activity(access_token, activity_id)
-		end
-
-
-		# Add an AddContacts activity to add contacts in bulk
-		# @param [String] access_token - Constant Contact OAuth2 access token
-		# @param [AddContacts] add_contacts - Add Contacts
-		# @return [Activity]
-		def add_add_contacts_activity(access_token, add_contacts)
-			Services::ActivityService.create_add_contacts_activity(access_token, add_contacts)
-		end
-
-
-		# Add a ClearLists Activity to remove all contacts from the provided lists
-		# @param [String] access_token - Constant Contact OAuth2 access token
-		# @param [Array<Lists>] lists - Add Contacts Activity
-		# @return [Activity]
-		def add_clear_lists_activity(access_token, lists)
-			Services::ActivityService.add_clear_lists_activity(access_token, lists)
-		end
-
-
-		# Add a Remove Contacts From Lists Activity
-		# @param [String] access_token - Constant Contact OAuth2 access token
-		# @param [Array<EmailAddress>] email_addresses - email addresses to be removed
-		# @param [Array<Lists>] lists - lists to remove the provided email addresses from
-		# @return [Activity]
-		def add_remove_contacts_from_lists_activity(access_token, email_addresses, lists)
-			Services::ActivityService.add_remove_contacts_from_lists_activity(access_token, email_addresses, lists)
-		end
-
-
-		# Create an Export Contacts Activity
-		# @param [String] access_token - Constant Contact OAuth2 access token
-		# @param [<Array>Contacts] export_contacts - Contacts to be exported
-		# @return [Activity]
-		def add_export_contacts_activity(access_token, export_contacts)
-			Services::ActivityService.add_export_contacts_activity(access_token, export_contacts)
-		end
-
-
-		private
-
-
-		# Get the id of object, or attempt to convert the argument to an int
-		# @param [Mixed] item - object or a numeric value
-		# @param [String] class_name - class name to test the given object against
-		# @raise IllegalArgumentException - if the item is not an instance of the class name given, or cannot be
-		# converted to a numeric value
-		# @return [Integer]
-		def get_argument_id(item, class_name)
-			item_id = nil
-			if item.is_a?(Integer)
-				item_id = item
-			elsif item.class.to_s.split('::').last == class_name
-				item_id = item.id
-			else
-				raise Exceptions::IllegalArgumentException.new(sprintf(Util::Config.get('errors.id_or_object'), class_name))
-			end
-			item_id
-		end
-
-
-		# Append the limit parameter, if the value is an integer
-		# @param [String] param - parameter value
-		# @return [Hash] the parameters as a hash object
-		def determine_param(param)
-			params = {}
-			if param
-				param = param.to_s
-				if param[0, 1] == '?'
-					hash_params = CGI::parse(param[1..-1])
-					params = Hash[*hash_params.collect {|key, value| [key, value.first] }.flatten]
-				else
-					params['limit'] = param
-				end
-			end
-			params
-		end
-
-	end
+    # Get lists
+    # @param [String] access_token - Valid access token
+    # @return [Array<ContactList>] Array of ContactList objects
+    def get_lists(access_token)
+      Services::ListService.get_lists(access_token)
+    end
+
+
+    # Get an individual list
+    # @param [String] access_token - Valid access token
+    # @param [Integer] list_id - Id of the list to retrieve
+    # @return [ContactList]
+    def get_list(access_token, list_id)
+      Services::ListService.get_list(access_token, list_id)
+    end
+
+
+    # Add a new list to an account
+    # @param [String] access_token - Valid access token
+    # @param [ContactList] list - List to add
+    # @return [ContactList]
+    def add_list(access_token, list)
+      Services::ListService.add_list(access_token, list)
+    end
+
+
+    # Update a contact list
+    # @param [String] access_token - Valid access token
+    # @param [ContactList] list - ContactList to update
+    # @return [ContactList]
+    def update_list(access_token, list)
+      Services::ListService.update_list(access_token, list)
+    end
+
+
+    # Get contact that belong to a specific list
+    # @param [String] access_token - Constant Contact OAuth2 access token
+    # @param [Mixed] list - Integer id of the list or ContactList object
+    # @raise [IllegalArgumentException] If contact is not an integer or contact
+    # @return [Array<Contact>] An array of contacts
+    def get_contacts_from_list(access_token, list)
+      list_id = get_argument_id(list, 'ContactList')
+      Services::ListService.get_contacts_from_list(access_token, list_id)
+    end
+
+
+    # Get a set of campaigns
+    # @param [String] access_token - Constant Contact OAuth2 access token
+    # @param [String] param - denotes the number of results per set, limited to 50, or a next parameter provided
+    # from a previous call
+    # @return [ResultSet<Campaign>]
+    def get_email_campaigns(access_token, param = nil)
+      param = determine_param(param)
+      Services::EmailMarketingService.get_campaigns(access_token, param)
+    end
+
+
+    # Get an individual campaign
+    # @param [String] access_token - Constant Contact OAuth2 access token
+    # @param [Integer] campaign_id - Valid campaign id
+    # @return [Campaign]
+    def get_email_campaign(access_token, campaign_id)
+      Services::EmailMarketingService.get_campaign(access_token, campaign_id)
+    end
+
+
+    # Delete an individual campaign
+    # @param [String] access_token - Constant Contact OAuth2 access token
+    # @param [Mixed] campaign - Id of a campaign or a Campaign object
+    # @raise IllegalArgumentException - if a Campaign object or campaign id is not passed
+    # @return [Boolean]
+    def delete_email_campaign(access_token, campaign)
+      campaign_id = get_argument_id(campaign, 'Campaign')
+      Services::EmailMarketingService.delete_campaign(access_token, campaign_id)
+    end
+
+
+    # Create a new campaign
+    # @param [String] access_token - Constant Contact OAuth2 access token
+    # @param [Campaign] campaign - Campaign to be created
+    # @return [Campaign] - created campaign
+    def add_email_campaign(access_token, campaign)
+      Services::EmailMarketingService.add_campaign(access_token, campaign)
+    end
+
+
+    # Update a specific campaign
+    # @param [String] access_token - Constant Contact OAuth2 access token
+    # @param [Campaign] campaign - Campaign to be updated
+    # @return [Campaign] - updated campaign
+    def update_email_campaign(access_token, campaign)
+      Services::EmailMarketingService.update_campaign(access_token, campaign)
+    end
+
+
+    # Schedule a campaign to be sent
+    # @param [String] access_token - Constant Contact OAuth2 access token
+    # @param [Mixed] campaign - Id of a campaign or a Campaign object
+    # @param [Schedule] schedule - Schedule to be associated with the provided campaign
+    # @return [Campaign] - updated campaign
+    def add_email_campaign_schedule(access_token, campaign, schedule)
+      campaign_id = get_argument_id(campaign, 'Campaign')
+      Services::CampaignScheduleService.add_schedule(access_token, campaign_id, schedule)
+    end
+
+
+    # Get an array of schedules associated with a given campaign
+    # @param [String] access_token - Constant Contact OAuth2 access token
+    # @param [Mixed] campaign - Campaign id or Campaign object itself
+    # @return [Array<Schedule>]
+    def get_email_campaign_schedules(access_token, campaign)
+      campaign_id = get_argument_id(campaign, 'Campaign')
+      Services::CampaignScheduleService.get_schedules(access_token, campaign_id)
+    end
+
+
+    # Get a specific schedule associated with a given campaign
+    # @param [String] access_token - Constant Contact OAuth2 access token
+    # @param [Mixed] campaign - Campaign id or Campaign object itself
+    # @param [Mixed] schedule - Schedule id or Schedule object itself
+    # @raise IllegalArgumentException
+    # @return [Schedule]
+    def get_email_campaign_schedule(access_token, campaign, schedule)
+      campaign_id = get_argument_id(campaign, 'Campaign')
+      schedule_id = get_argument_id(schedule, 'Schedule')
+      Services::CampaignScheduleService.get_schedule(access_token, campaign_id, schedule_id)
+    end
+
+
+    # Update a specific schedule associated with a given campaign
+    # @param [String] access_token - Constant Contact OAuth2 access token
+    # @param [Mixed] campaign - Campaign id or Campaign object itself
+    # @param [Schedule] schedule - Schedule to be updated
+    # @return [Schedule]
+    def update_email_campaign_schedule(access_token, campaign, schedule)
+      campaign_id = get_argument_id(campaign, 'Campaign')
+      Services::CampaignScheduleService.update_schedule(access_token, campaign_id, schedule)
+    end
+
+
+    # Delete a specific schedule associated with a given campaign
+    # @param [String] access_token - Constant Contact OAuth2 access token
+    # @param [Mixed] campaign - Campaign id or Campaign object itself
+    # @param [Mixed] schedule - Schedule id or Schedule object itself
+    # @raise IllegalArgumentException
+    # @return [Boolean]
+    def delete_email_campaign_schedule(access_token, campaign, schedule)
+      campaign_id = get_argument_id(campaign, 'Campaign')
+      schedule_id = get_argument_id(schedule, 'Schedule')
+      Services::CampaignScheduleService.delete_schedule(access_token, campaign_id, schedule_id)
+    end
+
+
+    # Send a test send of a campaign
+    # @param [String] access_token - Constant Contact OAuth2 access token
+    # @param [Mixed] campaign - Campaign id or Campaign object itself
+    # @param [TestSend] test_send - test send details
+    # @return [TestSend]
+    def send_email_campaign_test(access_token, campaign, test_send)
+      campaign_id = get_argument_id(campaign, 'Campaign')
+      Services::CampaignScheduleService.send_test(access_token, campaign_id, test_send)
+    end
+
+
+    # Get sends for a campaign
+    # @param [String] access_token - Constant Contact OAuth2 access token
+    # @param [Mixed] campaign - Campaign id or Campaign object itself
+    # @param [String] param - next value returned from a previous request (used in pagination)
+    # @return [ResultSet<SendActivity>]
+    def get_email_campaign_sends(access_token, campaign, param = nil)
+      campaign_id = get_argument_id(campaign, 'Campaign')
+      param = determine_param(param)
+      Services::CampaignTrackingService.get_sends(access_token, campaign_id, param)
+    end
+
+
+    # Get bounces for a campaign
+    # @param [String] access_token - Constant Contact OAuth2 access token
+    # @param [Mixed] campaign  - Campaign id or Campaign object itself
+    # @param [Mixed] param - either the next link from a previous request, or a limit or restrict the page size of
+    # an initial request
+    # @return [ResultSet<BounceActivity>]
+    def get_email_campaign_bounces(access_token, campaign, param = nil)
+      campaign_id = get_argument_id(campaign, 'Campaign')
+      param = determine_param(param)
+      Services::CampaignTrackingService.get_bounces(access_token, campaign_id, param)
+    end
+
+
+    # Get clicks for a campaign
+    # @param [String] access_token - Constant Contact OAuth2 access token
+    # @param [Mixed] campaign - Campaign id or Campaign object itself
+    # @param [Mixed] param - either the next link from a previous request, or a limit or restrict the page size of
+    # an initial request
+    # @return [ResultSet<ClickActivity>]
+    def get_email_campaign_clicks(access_token, campaign, param = nil)
+      campaign_id = get_argument_id(campaign, 'Campaign')
+      param = determine_param(param)
+      Services::CampaignTrackingService.get_clicks(access_token, campaign_id, param)
+    end
+
+
+    # Get opens for a campaign
+    # @param [String] access_token - Constant Contact OAuth2 access token
+    # @param [Mixed] campaign  - Campaign id or Campaign object itself
+    # @param [Mixed] param - either the next link from a previous request, or a limit or restrict the page size of
+    # an initial request
+    # @return [ResultSet<OpenActivity>]
+    def get_email_campaign_opens(access_token, campaign, param = nil)
+      campaign_id = get_argument_id(campaign, 'Campaign')
+      param = determine_param(param)
+      Services::CampaignTrackingService.get_opens(access_token, campaign_id, param)
+    end
+
+
+    # Get forwards for a campaign
+    # @param [String] access_token - Constant Contact OAuth2 access token
+    # @param [Mixed] campaign - Campaign id or Campaign object itself
+    # @param [Mixed] param - either the next link from a previous request, or a limit or restrict the page size of
+    # an initial request
+    # @return [ResultSet<ForwardActivity>]
+    def get_email_campaign_forwards(access_token, campaign, param = nil)
+      campaign_id = get_argument_id(campaign, 'Campaign')
+      param = determine_param(param)
+      Services::CampaignTrackingService.get_forwards(access_token, campaign_id, param)
+    end
+
+
+    # Get unsubscribes for a campaign
+    # @param [String] access_token - Constant Contact OAuth2 access token
+    # @param [Mixed] campaign - Campaign id or Campaign object itself
+    # @param [Mixed] param - either the next link from a previous request, or a limit or restrict the page size of
+    # an initial request
+    # @return [ResultSet<UnsubscribeActivity>] - Containing a results array of UnsubscribeActivity
+    def get_email_campaign_unsubscribes(access_token, campaign, param = nil)
+      campaign_id = get_argument_id(campaign, 'Campaign')
+      param = determine_param(param)
+      Services::CampaignTrackingService.get_unsubscribes(access_token, campaign_id, param)
+    end
+
+
+    # Get a reporting summary for a campaign
+    # @param [String] access_token - Constant Contact OAuth2 access token
+    # @param [Mixed] campaign  - Campaign id or Campaign object itself
+    # @return [TrackingSummary]
+    def get_email_campaign_summary_report(access_token, campaign)
+      campaign_id = get_argument_id(campaign, 'Campaign')
+      Services::CampaignTrackingService.get_summary(access_token, campaign_id)
+    end
+
+
+    # Get sends for a Contact
+    # @param [String] access_token - Constant Contact OAuth2 access token
+    # @param [Mixed] contact - Contact id or Contact object itself
+    # @param [Mixed] param - either the next link from a previous request, or a limit or restrict the page size of
+    # an initial request
+    # @return [ResultSet<SendActivity>]
+    def get_contact_sends(access_token, contact, param = nil)
+      contact_id = get_argument_id(contact, 'Contact')
+      Services::ContactTrackingService.get_sends(access_token, contact_id, param)
+    end
+
+
+    # Get bounces for a Contact
+    # @param [String] access_token - Constant Contact OAuth2 access token
+    # @param [Mixed] contact - Contact id or Contact object itself
+    # @param [Mixed] param - either the next link from a previous request, or a limit or restrict the page size of
+    # an initial request
+    # @return [ResultSet<BounceActivity>]
+    def get_contact_bounces(access_token, contact, param = nil)
+      contact_id = get_argument_id(contact, 'Contact')
+      Services::ContactTrackingService.get_bounces(access_token, contact_id, param)
+    end
+
+
+    # Get clicks for a Contact
+    # @param [String] access_token - Constant Contact OAuth2 access token
+    # @param [Mixed] contact - Contact id or Contact object itself
+    # @param [Mixed] param - either the next link from a previous request, or a limit or restrict the page size of
+    # an initial request
+    # @return [ResultSet<ClickActivity>]
+    def get_contact_clicks(access_token, contact, param = nil)
+      contact_id = get_argument_id(contact, 'Contact')
+      param = determine_param(param)
+      Services::ContactTrackingService.get_clicks(access_token, contact_id, param)
+    end
+
+
+    # Get opens for a Contact
+    # @param [String] access_token - Constant Contact OAuth2 access token
+    # @param [Mixed] contact  - Contact id or Contact object itself
+    # @param [Mixed] param - either the next link from a previous request, or a limit or restrict the page size of
+    # an initial request
+    # @return [ResultSet<OpenActivity>]
+    def get_contact_opens(access_token, contact, param = nil)
+      contact_id = get_argument_id(contact, 'Contact')
+      param = determine_param(param)
+      Services::ContactTrackingService.get_opens(access_token, contact_id, param)
+    end
+
+
+    # Get forwards for a Contact
+    # @param [String] access_token - Constant Contact OAuth2 access token
+    # @param [Mixed] contact  - Contact id or Contact object itself
+    # @param [Mixed] param - either the next link from a previous request, or a limit or restrict the page size of
+    # an initial request
+    # @return [ResultSet<ForwardActivity>]
+    def get_contact_forwards(access_token, contact, param = nil)
+      contact_id = get_argument_id(contact, 'Contact')
+      param = determine_param(param)
+      Services::ContactTrackingService.get_forwards(access_token, contact_id, param)
+    end
+
+
+    # Get unsubscribes for a Contact
+    # @param [String] access_token - Constant Contact OAuth2 access token
+    # @param [Mixed] contact - Contact id or Contact object itself
+    # @param [Hash] param - either the next link from a previous request, or a limit or restrict the page size of
+    # an initial request
+    # @return [UnsubscribeActivity] - Containing a results array of UnsubscribeActivity
+    def get_contact_unsubscribes(access_token, contact, param = nil)
+      contact_id = get_argument_id(contact, 'Contact')
+      param = determine_param(param)
+      Services::ContactTrackingService.get_unsubscribes(access_token, contact_id, param)
+    end
+
+
+    # Get a reporting summary for a Contact
+    # @param [String] access_token - Constant Contact OAuth2 access token
+    # @param [Mixed] contact - Contact id or Contact object itself
+    # @return [TrackingSummary]
+    def get_contact_summary_report(access_token, contact)
+      contact_id = get_argument_id(contact, 'Contact')
+      Services::ContactTrackingService.get_summary(access_token, contact_id)
+    end
+
+
+    # Get an array of activities
+    # @param [String] access_token - Constant Contact OAuth2 access token
+    # @return [Array<Activity>]
+    def get_activities(access_token)
+      Services::ActivityService.get_activities(access_token)
+    end
+
+
+    # Get a single activity by id
+    # @param [String] access_token - Constant Contact OAuth2 access token
+    # @param [String] activity_id - Activity id
+    # @return [Activity]
+    def get_activity(access_token, activity_id)
+      Services::ActivityService.get_activity(access_token, activity_id)
+    end
+
+
+    # Add an AddContacts activity to add contacts in bulk
+    # @param [String] access_token - Constant Contact OAuth2 access token
+    # @param [AddContacts] add_contacts - Add Contacts
+    # @return [Activity]
+    def add_add_contacts_activity(access_token, add_contacts)
+      Services::ActivityService.create_add_contacts_activity(access_token, add_contacts)
+    end
+
+
+    # Add a ClearLists Activity to remove all contacts from the provided lists
+    # @param [String] access_token - Constant Contact OAuth2 access token
+    # @param [Array<Lists>] lists - Add Contacts Activity
+    # @return [Activity]
+    def add_clear_lists_activity(access_token, lists)
+      Services::ActivityService.add_clear_lists_activity(access_token, lists)
+    end
+
+
+    # Add a Remove Contacts From Lists Activity
+    # @param [String] access_token - Constant Contact OAuth2 access token
+    # @param [Array<EmailAddress>] email_addresses - email addresses to be removed
+    # @param [Array<Lists>] lists - lists to remove the provided email addresses from
+    # @return [Activity]
+    def add_remove_contacts_from_lists_activity(access_token, email_addresses, lists)
+      Services::ActivityService.add_remove_contacts_from_lists_activity(access_token, email_addresses, lists)
+    end
+
+
+    # Create an Export Contacts Activity
+    # @param [String] access_token - Constant Contact OAuth2 access token
+    # @param [<Array>Contacts] export_contacts - Contacts to be exported
+    # @return [Activity]
+    def add_export_contacts_activity(access_token, export_contacts)
+      Services::ActivityService.add_export_contacts_activity(access_token, export_contacts)
+    end
+
+
+    private
+
+
+    # Get the id of object, or attempt to convert the argument to an int
+    # @param [Mixed] item - object or a numeric value
+    # @param [String] class_name - class name to test the given object against
+    # @raise IllegalArgumentException - if the item is not an instance of the class name given, or cannot be
+    # converted to a numeric value
+    # @return [Integer]
+    def get_argument_id(item, class_name)
+      item_id = nil
+      if item.is_a?(Integer)
+        item_id = item
+      elsif item.class.to_s.split('::').last == class_name
+        item_id = item.id
+      else
+        raise Exceptions::IllegalArgumentException.new(sprintf(Util::Config.get('errors.id_or_object'), class_name))
+      end
+      item_id
+    end
+
+
+    # Append the limit parameter, if the value is an integer
+    # @param [String] param - parameter value
+    # @return [Hash] the parameters as a hash object
+    def determine_param(param)
+      params = {}
+      if param
+        param = param.to_s
+        if param[0, 1] == '?'
+          hash_params = CGI::parse(param[1..-1])
+          params = Hash[*hash_params.collect {|key, value| [key, value.first] }.flatten]
+        else
+          params['limit'] = param
+        end
+      end
+      params
+    end
+
+  end
 end

--- a/lib/constantcontact/auth/oauth2.rb
+++ b/lib/constantcontact/auth/oauth2.rb
@@ -5,78 +5,78 @@
 # Copyright (c) 2013 Constant Contact. All rights reserved.
 
 module ConstantContact
-	module Auth
-		class OAuth2
-			attr_accessor :client_id, :client_secret, :redirect_uri, :props
+  module Auth
+    class OAuth2
+      attr_accessor :client_id, :client_secret, :redirect_uri, :props
 
 
-			# Class constructor
-			# @param [Hash] opts - the options to create an OAuth2 object with
-			# @option opts [String] :api_key - the Constant Contact API Key
-			# @option opts [String] :api_secret - the Constant Contact secret key
-			# @option opts [String] :redirect_url - the URL where Constact Contact is returning the authorization code
-			# @return
-			def initialize(opts)
-				@client_id = opts[:api_key]
-				@client_secret = opts[:api_secret]
-				@redirect_uri = opts[:redirect_url]
-			end
+      # Class constructor
+      # @param [Hash] opts - the options to create an OAuth2 object with
+      # @option opts [String] :api_key - the Constant Contact API Key
+      # @option opts [String] :api_secret - the Constant Contact secret key
+      # @option opts [String] :redirect_url - the URL where Constact Contact is returning the authorization code
+      # @return
+      def initialize(opts)
+        @client_id = opts[:api_key]
+        @client_secret = opts[:api_secret]
+        @redirect_uri = opts[:redirect_url]
+      end
 
 
-			# Get the URL at which the user can authenticate and authorize the requesting application
-			# @param [Boolean] server - whether or not to use OAuth2 server flow, alternative is client flow
-			# @return [String] the authorization URL
-			def get_authorization_url(server = true)
-				response_type = server ? Util::Config.get('auth.response_type_code') : Util::Config.get('auth.response_type_token')
-				params = {
-					:response_type => response_type,
-					:client_id     => @client_id,
-					:redirect_uri  => @redirect_uri
-				}
-				[
-					Util::Config.get('auth.base_url'),
-					Util::Config.get('auth.authorization_endpoint'),
-					'?',
-					Util::Helpers.http_build_query(params)
-				].join
-			end
+      # Get the URL at which the user can authenticate and authorize the requesting application
+      # @param [Boolean] server - whether or not to use OAuth2 server flow, alternative is client flow
+      # @return [String] the authorization URL
+      def get_authorization_url(server = true)
+        response_type = server ? Util::Config.get('auth.response_type_code') : Util::Config.get('auth.response_type_token')
+        params = {
+          :response_type => response_type,
+          :client_id     => @client_id,
+          :redirect_uri  => @redirect_uri
+        }
+        [
+          Util::Config.get('auth.base_url'),
+          Util::Config.get('auth.authorization_endpoint'),
+          '?',
+          Util::Helpers.http_build_query(params)
+        ].join
+      end
 
 
-			# Obtain an access token
-			# @param [String] code - the code returned from Constant Contact after a user has granted access to his account
-			# @return [String] the access token
-			def get_access_token(code)
-				params = {
-					:grant_type    => Util::Config.get('auth.authorization_code_grant_type'),
-					:client_id     => @client_id,
-					:client_secret => @client_secret,
-					:code          => code,
-					:redirect_uri  => @redirect_uri
-				}
+      # Obtain an access token
+      # @param [String] code - the code returned from Constant Contact after a user has granted access to his account
+      # @return [String] the access token
+      def get_access_token(code)
+        params = {
+          :grant_type    => Util::Config.get('auth.authorization_code_grant_type'),
+          :client_id     => @client_id,
+          :client_secret => @client_secret,
+          :code          => code,
+          :redirect_uri  => @redirect_uri
+        }
 
-				url = [
-					Util::Config.get('auth.base_url'),
-					Util::Config.get('auth.token_endpoint')
-				].join
+        url = [
+          Util::Config.get('auth.base_url'),
+          Util::Config.get('auth.token_endpoint')
+        ].join
 
-				response_body = ''
-				begin
-					response = RestClient.post(url, params)
-					response_body = JSON.parse(response)
-				rescue => e
-					response_body = e.respond_to?(:response) ?
-						JSON.parse(e.response) :
-						{'error' => '', 'error_description' => e.message}
-				end
+        response_body = ''
+        begin
+          response = RestClient.post(url, params)
+          response_body = JSON.parse(response)
+        rescue => e
+          response_body = e.respond_to?(:response) ?
+            JSON.parse(e.response) :
+            {'error' => '', 'error_description' => e.message}
+        end
 
-				if response_body['error_description']
-					error = response_body['error_description']
-					raise Exceptions::OAuth2Exception, error
-				end
+        if response_body['error_description']
+          error = response_body['error_description']
+          raise Exceptions::OAuth2Exception, error
+        end
 
-				response_body
-			end
+        response_body
+      end
 
-		end
-	end
+    end
+  end
 end

--- a/lib/constantcontact/auth/session_data_store.rb
+++ b/lib/constantcontact/auth/session_data_store.rb
@@ -5,65 +5,65 @@
 # Copyright (c) 2013 Constant Contact. All rights reserved.
 
 module ConstantContact
-	module Auth
-		class Session
-			attr_accessor :session
+  module Auth
+    class Session
+      attr_accessor :session
 
-			# Create and initialize the session
-			def initialize
-				cgi = CGI.new('html4')
+      # Create and initialize the session
+      def initialize
+        cgi = CGI.new('html4')
 
-				# We make sure to delete an old session if one exists,
-				# not just to free resources, but to prevent the session
-				# from being maliciously hijacked later on.
-				begin
-					@session = CGI::Session.new(cgi, 'database_manager' => CGI::Session::PStore, 'new_session' => false)
-					@session.delete
-				rescue ArgumentError # if no old session
-				end
-				@session = CGI::Session.new(cgi, 'database_manager' => CGI::Session::PStore, 'new_session' => true)
-				@session['datastore'] = {}
-			end
+        # We make sure to delete an old session if one exists,
+        # not just to free resources, but to prevent the session
+        # from being maliciously hijacked later on.
+        begin
+          @session = CGI::Session.new(cgi, 'database_manager' => CGI::Session::PStore, 'new_session' => false)
+          @session.delete
+        rescue ArgumentError # if no old session
+        end
+        @session = CGI::Session.new(cgi, 'database_manager' => CGI::Session::PStore, 'new_session' => true)
+        @session['datastore'] = {}
+      end
 
-			# Add a new user to the data store
-			# @param [String] username - Constant Contact username
-			# @param [Hash] params - additional parameters
-			# @return
-			def add_user(username, params)
-				@session['datastore'][username] = params
-			end
+      # Add a new user to the data store
+      # @param [String] username - Constant Contact username
+      # @param [Hash] params - additional parameters
+      # @return
+      def add_user(username, params)
+        @session['datastore'][username] = params
+      end
 
-			# Get an existing user from the data store
-			# @param [String] username - Constant Contact username key
-			# @return [String] The username value
-			def get_user(username)
-				@session['datastore'].has_key?(username) ? @session['datastore'][username] : false
-			end
+      # Get an existing user from the data store
+      # @param [String] username - Constant Contact username key
+      # @return [String] The username value
+      def get_user(username)
+        @session['datastore'].has_key?(username) ? @session['datastore'][username] : false
+      end
 
-			# Update an existing user in the data store
-			# @param [String] username - Constant Contact username
-			# @param [Hash] params - additional parameters
-			# @return
-			def update_user(username, params)
-				if @session['datastore'].has_key?(username)
-					@session['datastore'][username] = params
-				end
-			end
+      # Update an existing user in the data store
+      # @param [String] username - Constant Contact username
+      # @param [Hash] params - additional parameters
+      # @return
+      def update_user(username, params)
+        if @session['datastore'].has_key?(username)
+          @session['datastore'][username] = params
+        end
+      end
 
-			# Delete an existing user from the data store
-			# @param [String] username - Constant Contact username
-			# @return
-			def delete_user(username)
-				@session['datastore'][username] = nil
-			end
+      # Delete an existing user from the data store
+      # @param [String] username - Constant Contact username
+      # @return
+      def delete_user(username)
+        @session['datastore'][username] = nil
+      end
 
-			# Close current session
-			# @return
-			def close
-				@session.close
-			end
+      # Close current session
+      # @return
+      def close
+        @session.close
+      end
 
-		end
-	end
+    end
+  end
 end
 

--- a/lib/constantcontact/components/account/verified_email_address.rb
+++ b/lib/constantcontact/components/account/verified_email_address.rb
@@ -5,23 +5,23 @@
 # Copyright (c) 2013 Constant Contact. All rights reserved.
 
 module ConstantContact
-	module Components
-		class VerifiedEmailAddress < Component
-			attr_accessor :status, :email_address
+  module Components
+    class VerifiedEmailAddress < Component
+      attr_accessor :status, :email_address
 
-			# Factory method to create a VerifiedEmailAddress object from a json string
-			# @param [Hash] props - array of properties to create object from
-			# @return [VerifiedEmailAddress]
-			def self.create(props)
-				email_address = VerifiedEmailAddress.new
-				if props
-					props.each do |key, value|
-						email_address.send("#{key}=", value)
-					end
-				end
-				email_address
-			end
+      # Factory method to create a VerifiedEmailAddress object from a json string
+      # @param [Hash] props - array of properties to create object from
+      # @return [VerifiedEmailAddress]
+      def self.create(props)
+        email_address = VerifiedEmailAddress.new
+        if props
+          props.each do |key, value|
+            email_address.send("#{key}=", value)
+          end
+        end
+        email_address
+      end
 
-		end
-	end
+    end
+  end
 end

--- a/lib/constantcontact/components/activities/activity.rb
+++ b/lib/constantcontact/components/activities/activity.rb
@@ -5,40 +5,40 @@
 # Copyright (c) 2013 Constant Contact. All rights reserved.
 
 module ConstantContact
-	module Components
-		class Activity < Component
-			attr_accessor :id, :type, :status, :start_date, :finish_date, :file_name, :created_date,
-										:error_count, :errors, :warnings, :contact_count
+  module Components
+    class Activity < Component
+      attr_accessor :id, :type, :status, :start_date, :finish_date, :file_name, :created_date,
+                    :error_count, :errors, :warnings, :contact_count
 
-			# Factory method to create an Activity object from a json string
-			# @param [Hash] props - hash of properties to create object from
-			# @return [Activity]
-			def self.create(props)
-				activity = Activity.new
-				if props
-					props.each do |key, value|
-						if key == 'errors'
-							if value
-								activity.errors = []
-								value.each do |error|
-									activity.errors << Components::ActivityError.create(error)
-								end
-							end
-						elsif key == 'warnings'
-							if value
-								activity.warnings = []
-								value.each do |error|
-									activity.warnings << Components::ActivityError.create(error)
-								end
-							end
-						else
-							activity.send("#{key}=", value)
-						end
-					end
-				end
-				activity
-			end
+      # Factory method to create an Activity object from a json string
+      # @param [Hash] props - hash of properties to create object from
+      # @return [Activity]
+      def self.create(props)
+        activity = Activity.new
+        if props
+          props.each do |key, value|
+            if key == 'errors'
+              if value
+                activity.errors = []
+                value.each do |error|
+                  activity.errors << Components::ActivityError.create(error)
+                end
+              end
+            elsif key == 'warnings'
+              if value
+                activity.warnings = []
+                value.each do |error|
+                  activity.warnings << Components::ActivityError.create(error)
+                end
+              end
+            else
+              activity.send("#{key}=", value)
+            end
+          end
+        end
+        activity
+      end
 
-		end
-	end
+    end
+  end
 end

--- a/lib/constantcontact/components/activities/activity_error.rb
+++ b/lib/constantcontact/components/activities/activity_error.rb
@@ -5,23 +5,23 @@
 # Copyright (c) 2013 Constant Contact. All rights reserved.
 
 module ConstantContact
-	module Components
-		class ActivityError < Component
-			attr_accessor :message, :line_number, :email_address
+  module Components
+    class ActivityError < Component
+      attr_accessor :message, :line_number, :email_address
 
-			# Factory method to create an ActivityError object from an array
-			# @param [Hash] props - hash of properties to create object from
-			# @return [ActivityError]
-			def self.create(props)
-				activity_error = ActivityError.new
-				if props
-					props.each do |key, value|
-						activity_error.send("#{key}=", value)
-					end
-				end
-				activity_error
-			end
+      # Factory method to create an ActivityError object from an array
+      # @param [Hash] props - hash of properties to create object from
+      # @return [ActivityError]
+      def self.create(props)
+        activity_error = ActivityError.new
+        if props
+          props.each do |key, value|
+            activity_error.send("#{key}=", value)
+          end
+        end
+        activity_error
+      end
 
-		end
-	end
+    end
+  end
 end

--- a/lib/constantcontact/components/activities/add_contacts.rb
+++ b/lib/constantcontact/components/activities/add_contacts.rb
@@ -5,113 +5,113 @@
 # Copyright (c) 2013 Constant Contact. All rights reserved.
 
 module ConstantContact
-	module Components
-		class AddContacts < Component
-			attr_accessor :import_data, :lists, :column_names
+  module Components
+    class AddContacts < Component
+      attr_accessor :import_data, :lists, :column_names
 
-			# Constructor to create an AddContacts object from the given contacts and contact lists
-			# @param [Array<Contact>] contacts - contacts array
-			# @param [Array<ContactList>] lists - contact lists array]
-			# @param [Array<String>] column_names - array of column names
-			# @return [AddContacts]
-			def initialize(contacts, lists, column_names = [])
-				if !contacts.empty?
-					if contacts[0].instance_of?(Components::AddContactsImportData)
-						@import_data = contacts
-					else
-						raise Exceptions::IllegalArgumentException, sprintf(Util::Config.get('errors.id_or_object'), 'AddContactsImportData')
-					end
-				end
+      # Constructor to create an AddContacts object from the given contacts and contact lists
+      # @param [Array<Contact>] contacts - contacts array
+      # @param [Array<ContactList>] lists - contact lists array]
+      # @param [Array<String>] column_names - array of column names
+      # @return [AddContacts]
+      def initialize(contacts, lists, column_names = [])
+        if !contacts.empty?
+          if contacts[0].instance_of?(Components::AddContactsImportData)
+            @import_data = contacts
+          else
+            raise Exceptions::IllegalArgumentException, sprintf(Util::Config.get('errors.id_or_object'), 'AddContactsImportData')
+          end
+        end
 
-				@lists = lists
-				@column_names = column_names
+        @lists = lists
+        @column_names = column_names
 
-				# attempt to determine the column names being used if they are not provided
-				if column_names.empty?
-					used_columns = [Util::Config.get('activities_columns.email')]
+        # attempt to determine the column names being used if they are not provided
+        if column_names.empty?
+          used_columns = [Util::Config.get('activities_columns.email')]
 
-					contact = contacts[0]
+          contact = contacts[0]
 
-					if !contact.first_name.nil?
-						used_columns << Util::Config.get('activities_columns.first_name')
-					end
+          if !contact.first_name.nil?
+            used_columns << Util::Config.get('activities_columns.first_name')
+          end
 
-					if !contact.middle_name.nil?
-						used_columns << Util::Config.get('activities_columns.middle_name')
-					end
+          if !contact.middle_name.nil?
+            used_columns << Util::Config.get('activities_columns.middle_name')
+          end
 
-					if !contact.last_name.nil?
-						used_columns << Util::Config.get('activities_columns.last_name')
-					end
+          if !contact.last_name.nil?
+            used_columns << Util::Config.get('activities_columns.last_name')
+          end
 
-					if !contact.job_title.nil?
-						used_columns << Util::Config.get('activities_columns.job_title')
-					end
+          if !contact.job_title.nil?
+            used_columns << Util::Config.get('activities_columns.job_title')
+          end
 
-					if !contact.company_name.nil?
-						used_columns << Util::Config.get('activities_columns.company_name')
-					end
+          if !contact.company_name.nil?
+            used_columns << Util::Config.get('activities_columns.company_name')
+          end
 
-					if !contact.work_phone.nil?
-						used_columns << Util::Config.get('activities_columns.work_phone')
-					end
+          if !contact.work_phone.nil?
+            used_columns << Util::Config.get('activities_columns.work_phone')
+          end
 
-					if !contact.home_phone.nil?
-						used_columns << Util::Config.get('activities_columns.home_phone')
-					end
+          if !contact.home_phone.nil?
+            used_columns << Util::Config.get('activities_columns.home_phone')
+          end
 
-					address = contact.addresses[0]
+          address = contact.addresses[0]
 
-					if !address.line1.nil?
-						used_columns << Util::Config.get('activities_columns.address1')
-					end
+          if !address.line1.nil?
+            used_columns << Util::Config.get('activities_columns.address1')
+          end
 
-					if !address.line2.nil?
-						used_columns << Util::Config.get('activities_columns.address2')
-					end
+          if !address.line2.nil?
+            used_columns << Util::Config.get('activities_columns.address2')
+          end
 
-					if !address.line3.nil?
-						used_columns << Util::Config.get('activities_columns.address3')
-					end
+          if !address.line3.nil?
+            used_columns << Util::Config.get('activities_columns.address3')
+          end
 
-					if !address.city.nil?
-						used_columns << Util::Config.get('activities_columns.city')
-					end
+          if !address.city.nil?
+            used_columns << Util::Config.get('activities_columns.city')
+          end
 
-					if !address.state_code.nil?
-						used_columns << Util::Config.get('activities_columns.state')
-					end
+          if !address.state_code.nil?
+            used_columns << Util::Config.get('activities_columns.state')
+          end
 
-					if !address.state_code.nil?
-						used_columns << Util::Config.get('activities_columns.state_province')
-					end
+          if !address.state_code.nil?
+            used_columns << Util::Config.get('activities_columns.state_province')
+          end
 
-					if !address.country_code.nil?
-						used_columns << Util::Config.get('activities_columns.country')
-					end
+          if !address.country_code.nil?
+            used_columns << Util::Config.get('activities_columns.country')
+          end
 
-					if !address.postal_code.nil?
-						used_columns << Util::Config.get('activities_columns.postal_code')
-					end
+          if !address.postal_code.nil?
+            used_columns << Util::Config.get('activities_columns.postal_code')
+          end
 
-					if !address.sub_postal_code.nil?
-						used_columns << Util::Config.get('activities_columns.sub_postal_code')
-					end
+          if !address.sub_postal_code.nil?
+            used_columns << Util::Config.get('activities_columns.sub_postal_code')
+          end
 
-					# Custom Fields
-					if !contact.custom_fields.nil?
-						contact.custom_fields.each do |custom_field|
-							if custom_field.name.match('custom_field_')
-								custom_field_number = custom_field.name[13, custom_field.length]
-								used_columns << Util::Config.get('activities_columns.custom_field_' + custom_field_number)
-							end
-						end
-					end
+          # Custom Fields
+          if !contact.custom_fields.nil?
+            contact.custom_fields.each do |custom_field|
+              if custom_field.name.match('custom_field_')
+                custom_field_number = custom_field.name[13, custom_field.length]
+                used_columns << Util::Config.get('activities_columns.custom_field_' + custom_field_number)
+              end
+            end
+          end
 
-					@column_names = used_columns
-				end
-			end
+          @column_names = used_columns
+        end
+      end
 
-		end
-	end
+    end
+  end
 end

--- a/lib/constantcontact/components/activities/add_contacts_import_data.rb
+++ b/lib/constantcontact/components/activities/add_contacts_import_data.rb
@@ -5,41 +5,41 @@
 # Copyright (c) 2013 Constant Contact. All rights reserved.
 
 module ConstantContact
-	module Components
-		class AddContactsImportData < Component
-			attr_accessor :first_name, :middle_name, :last_name, :job_title, :company_name,
-										:work_phone, :home_phone, :email_addresses, :addresses, :custom_fields
+  module Components
+    class AddContactsImportData < Component
+      attr_accessor :first_name, :middle_name, :last_name, :job_title, :company_name,
+                    :work_phone, :home_phone, :email_addresses, :addresses, :custom_fields
 
 
-			# Constructor to create an AddContactsImportData object from the given hash
-			# @param [Hash] props - the hash with properties
-			# @return [AddContactsImportData]
-			def initialize(props = {})
-				instance_variables.each do |property, value|
-					send("#{property}=", get_value(props, property))
-				end
-			end
+      # Constructor to create an AddContactsImportData object from the given hash
+      # @param [Hash] props - the hash with properties
+      # @return [AddContactsImportData]
+      def initialize(props = {})
+        instance_variables.each do |property, value|
+          send("#{property}=", get_value(props, property))
+        end
+      end
 
-			# Setter
-			def add_custom_field(custom_field)
-				@custom_fields = [] if @custom_fields.nil?
-				@custom_fields << custom_field
-			end
-
-
-			# Setter
-			def add_address(address)
-				@addresses = [] if @addresses.nil?
-				@addresses << address
-			end
+      # Setter
+      def add_custom_field(custom_field)
+        @custom_fields = [] if @custom_fields.nil?
+        @custom_fields << custom_field
+      end
 
 
-			# Setter
-			def add_email(email_address)
-				@email_addresses = [] if @email_addresses.nil?
-				@email_addresses << email_address
-			end
+      # Setter
+      def add_address(address)
+        @addresses = [] if @addresses.nil?
+        @addresses << address
+      end
 
-		end
-	end
+
+      # Setter
+      def add_email(email_address)
+        @email_addresses = [] if @email_addresses.nil?
+        @email_addresses << email_address
+      end
+
+    end
+  end
 end

--- a/lib/constantcontact/components/activities/export_contacts.rb
+++ b/lib/constantcontact/components/activities/export_contacts.rb
@@ -5,26 +5,26 @@
 # Copyright (c) 2013 Constant Contact. All rights reserved.
 
 module ConstantContact
-	module Components
-		class ExportContacts < Component
-			attr_accessor :file_type, :sort_by, :export_date_added,
-										:export_added_by, :lists, :column_names
+  module Components
+    class ExportContacts < Component
+      attr_accessor :file_type, :sort_by, :export_date_added,
+                    :export_added_by, :lists, :column_names
 
 
-			# Constructor to create an ExportContacts object
-			# @param [Array] lists - array of lists ids
-			# @return [ExportContacts]
-			def initialize(lists = nil)
-				if !lists.nil?
-					@lists = lists
-				end
-				@file_type = 'CSV'
-				@sort_by = 'EMAIL_ADDRESS'
-				@export_date_added = true
-				@export_added_by = true
-				@column_names = ['Email Address', 'First Name', 'Last Name']
-			end
+      # Constructor to create an ExportContacts object
+      # @param [Array] lists - array of lists ids
+      # @return [ExportContacts]
+      def initialize(lists = nil)
+        if !lists.nil?
+          @lists = lists
+        end
+        @file_type = 'CSV'
+        @sort_by = 'EMAIL_ADDRESS'
+        @export_date_added = true
+        @export_added_by = true
+        @column_names = ['Email Address', 'First Name', 'Last Name']
+      end
 
-		end
-	end
+    end
+  end
 end

--- a/lib/constantcontact/components/component.rb
+++ b/lib/constantcontact/components/component.rb
@@ -5,19 +5,19 @@
 # Copyright (c) 2013 Constant Contact. All rights reserved.
 
 module ConstantContact
-	module Components
-		class Component
-			protected
+  module Components
+    class Component
+      protected
 
-			# Get the requested value from a hash, or return the default
-			# @param [Hash] hsh - the hash to search for the provided hash key
-			# @param [String] key - hash key to look for
-			# @param [String] default - value to return if the key is not found, default is null
-			# @return [String]
-			def self.get_value(hsh, key, default = nil)
-				hsh.has_key?(key) and hsh[key] ? hsh[key] : default
-			end
+      # Get the requested value from a hash, or return the default
+      # @param [Hash] hsh - the hash to search for the provided hash key
+      # @param [String] key - hash key to look for
+      # @param [String] default - value to return if the key is not found, default is null
+      # @return [String]
+      def self.get_value(hsh, key, default = nil)
+        hsh.has_key?(key) and hsh[key] ? hsh[key] : default
+      end
 
-		end
-	end
+    end
+  end
 end

--- a/lib/constantcontact/components/contacts/address.rb
+++ b/lib/constantcontact/components/contacts/address.rb
@@ -5,24 +5,24 @@
 # Copyright (c) 2013 Constant Contact. All rights reserved.
 
 module ConstantContact
-	module Components
-		class Address < Component
-			attr_accessor :id, :line1, :line2, :line3, :city, :address_type, :state_code,
-										:country_code, :postal_code, :sub_postal_code
+  module Components
+    class Address < Component
+      attr_accessor :id, :line1, :line2, :line3, :city, :address_type, :state_code,
+                    :country_code, :postal_code, :sub_postal_code
 
-			# Factory method to create an Address object from a json string
-			# @param [Hash] props - array of properties to create object from
-			# @return [Address]
-			def self.create(props)
-				address = Address.new
-				if props
-					props.each do |key, value|
-						address.send("#{key}=", value)
-					end
-				end
-				address
-			end
+      # Factory method to create an Address object from a json string
+      # @param [Hash] props - array of properties to create object from
+      # @return [Address]
+      def self.create(props)
+        address = Address.new
+        if props
+          props.each do |key, value|
+            address.send("#{key}=", value)
+          end
+        end
+        address
+      end
 
-		end
-	end
+    end
+  end
 end

--- a/lib/constantcontact/components/contacts/contact.rb
+++ b/lib/constantcontact/components/contacts/contact.rb
@@ -5,82 +5,82 @@
 # Copyright (c) 2013 Constant Contact. All rights reserved.
 
 module ConstantContact
-	module Components
-		class Contact < Component
+  module Components
+    class Contact < Component
 
-			attr_accessor :id, :status, :first_name, :middle_name, :last_name, :confirmed, :email_addresses,
-										:prefix_name, :job_title, :addresses, :company_name, :home_phone,
-										:work_phone, :cell_phone, :fax, :custom_fields, :lists,
-										:source_details, :source_is_url, :web_url, :modified_date,
-										:created_date, :notes, :source
-
-
-			# Factory method to create a Contact object from a json string
-			# @param [Hash] props - JSON string representing a contact
-			# @return [Contact]
-			def self.create(props)
-				contact = Contact.new
-				if props
-					props.each do |key, value|
-						if key == 'email_addresses'
-							if value
-								contact.email_addresses = []
-								value.each do |email_address|
-									contact.email_addresses << Components::EmailAddress.create(email_address)
-								end
-							end
-						elsif key == 'addresses'
-							if value
-								contact.addresses = []
-								value.each do |address|
-									contact.addresses << Components::Address.create(address)
-								end
-							end
-						elsif key == 'custom_fields'
-							if value
-								contact.custom_fields = []
-								value.each do |custom_field|
-									contact.custom_fields << Components::CustomField.create(custom_field)
-								end
-							end
-						elsif key == 'lists'
-							if value
-								contact.lists = []
-								value.each do |contact_list|
-									contact.lists << Components::ContactList.create(contact_list)
-								end
-							end
-						else
-							contact.send("#{key}=", value)
-						end
-					end
-				end
-				contact
-			end
-
-			# Setter
-			# @param [ContactList] contact_list
-			def add_list(contact_list)
-				@lists = [] if @lists.nil?
-				@lists << contact_list
-			end
+      attr_accessor :id, :status, :first_name, :middle_name, :last_name, :confirmed, :email_addresses,
+                    :prefix_name, :job_title, :addresses, :company_name, :home_phone,
+                    :work_phone, :cell_phone, :fax, :custom_fields, :lists,
+                    :source_details, :source_is_url, :web_url, :modified_date,
+                    :created_date, :notes, :source
 
 
-			# Setter
-			# @param [EmailAddress] email_address
-			def add_email(email_address)
-				@email_addresses = [] if @email_addresses.nil?
-				@email_addresses << email_address
-			end
+      # Factory method to create a Contact object from a json string
+      # @param [Hash] props - JSON string representing a contact
+      # @return [Contact]
+      def self.create(props)
+        contact = Contact.new
+        if props
+          props.each do |key, value|
+            if key == 'email_addresses'
+              if value
+                contact.email_addresses = []
+                value.each do |email_address|
+                  contact.email_addresses << Components::EmailAddress.create(email_address)
+                end
+              end
+            elsif key == 'addresses'
+              if value
+                contact.addresses = []
+                value.each do |address|
+                  contact.addresses << Components::Address.create(address)
+                end
+              end
+            elsif key == 'custom_fields'
+              if value
+                contact.custom_fields = []
+                value.each do |custom_field|
+                  contact.custom_fields << Components::CustomField.create(custom_field)
+                end
+              end
+            elsif key == 'lists'
+              if value
+                contact.lists = []
+                value.each do |contact_list|
+                  contact.lists << Components::ContactList.create(contact_list)
+                end
+              end
+            else
+              contact.send("#{key}=", value)
+            end
+          end
+        end
+        contact
+      end
+
+      # Setter
+      # @param [ContactList] contact_list
+      def add_list(contact_list)
+        @lists = [] if @lists.nil?
+        @lists << contact_list
+      end
 
 
-			# Setter
-			# @param [Address] address
-			def add_address(address)
-				@addresses = [] if @addresses.nil?
-				@addresses << address
-			end
+      # Setter
+      # @param [EmailAddress] email_address
+      def add_email(email_address)
+        @email_addresses = [] if @email_addresses.nil?
+        @email_addresses << email_address
+      end
 
-		end
-	end
+
+      # Setter
+      # @param [Address] address
+      def add_address(address)
+        @addresses = [] if @addresses.nil?
+        @addresses << address
+      end
+
+    end
+  end
 end

--- a/lib/constantcontact/components/contacts/contact_list.rb
+++ b/lib/constantcontact/components/contacts/contact_list.rb
@@ -5,23 +5,23 @@
 # Copyright (c) 2013 Constant Contact. All rights reserved.
 
 module ConstantContact
-	module Components
-		class ContactList < Component
-			attr_accessor :id, :name, :status, :contact_count, :opt_in_default
+  module Components
+    class ContactList < Component
+      attr_accessor :id, :name, :status, :contact_count, :opt_in_default
 
-			# Factory method to create a ContactList object from a json string
-			# @param [Hash] props - array of properties to create object from
-			# @return [ContactList]
-			def self.create(props)
-				contact_list = ContactList.new
-				if props
-					props.each do |key, value|
-						contact_list.send("#{key}=", value)
-					end
-				end
-				contact_list
-			end
+      # Factory method to create a ContactList object from a json string
+      # @param [Hash] props - array of properties to create object from
+      # @return [ContactList]
+      def self.create(props)
+        contact_list = ContactList.new
+        if props
+          props.each do |key, value|
+            contact_list.send("#{key}=", value)
+          end
+        end
+        contact_list
+      end
 
-		end
-	end
+    end
+  end
 end

--- a/lib/constantcontact/components/contacts/custom_field.rb
+++ b/lib/constantcontact/components/contacts/custom_field.rb
@@ -5,23 +5,23 @@
 # Copyright (c) 2013 Constant Contact. All rights reserved.
 
 module ConstantContact
-	module Components
-		class CustomField < Component
-			attr_accessor :name, :value
+  module Components
+    class CustomField < Component
+      attr_accessor :name, :value
 
-			# Factory method to create a CustomField object from a json string
-			# @param [Hash] props - array of properties to create object from
-			# @return [CustomField]
-			def self.create(props)
-				custom_field = CustomField.new
-				if props
-					props.each do |key, value|
-						custom_field.send("#{key}=", value)
-					end
-				end
-				custom_field
-			end
+      # Factory method to create a CustomField object from a json string
+      # @param [Hash] props - array of properties to create object from
+      # @return [CustomField]
+      def self.create(props)
+        custom_field = CustomField.new
+        if props
+          props.each do |key, value|
+            custom_field.send("#{key}=", value)
+          end
+        end
+        custom_field
+      end
 
-		end
-	end
+    end
+  end
 end

--- a/lib/constantcontact/components/contacts/email_address.rb
+++ b/lib/constantcontact/components/contacts/email_address.rb
@@ -5,30 +5,30 @@
 # Copyright (c) 2013 Constant Contact. All rights reserved.
 
 module ConstantContact
-	module Components
-		class EmailAddress < Component
-			attr_accessor :id, :status, :confirm_status, :opt_in_source, :opt_in_date, :opt_out_date, :email_address
+  module Components
+    class EmailAddress < Component
+      attr_accessor :id, :status, :confirm_status, :opt_in_source, :opt_in_date, :opt_out_date, :email_address
 
-			# Class constructor
-			# @param [String] email_address
-			# @return [EmailAddress]
-			def initialize(email_address = nil)
-				@email_address = email_address if email_address
-			end
+      # Class constructor
+      # @param [String] email_address
+      # @return [EmailAddress]
+      def initialize(email_address = nil)
+        @email_address = email_address if email_address
+      end
 
-			# Factory method to create an EmailAddress object from a json string
-			# @param [Hash] props - array of properties to create object from
-			# @return [EmailAddress]
-			def self.create(props)
-				email_address = EmailAddress.new
-				if props
-					props.each do |key, value|
-						email_address.send("#{key}=", value)
-					end
-				end
-				email_address
-			end
+      # Factory method to create an EmailAddress object from a json string
+      # @param [Hash] props - array of properties to create object from
+      # @return [EmailAddress]
+      def self.create(props)
+        email_address = EmailAddress.new
+        if props
+          props.each do |key, value|
+            email_address.send("#{key}=", value)
+          end
+        end
+        email_address
+      end
 
-		end
-	end
+    end
+  end
 end

--- a/lib/constantcontact/components/contacts/note.rb
+++ b/lib/constantcontact/components/contacts/note.rb
@@ -5,21 +5,21 @@
 # Copyright (c) 2013 Constant Contact. All rights reserved.
 
 module ConstantContact
-	module Components
-		class Note < Component
-			attr_accessor :id, :note, :created_date
+  module Components
+    class Note < Component
+      attr_accessor :id, :note, :created_date
 
-			# Factory method to create a Note object from a json string
-			# @param props - JSON string representing a contact
-			# @return Note
-			def self.create(props)
-				note = Note.new
-				if props
-					props.each do |key, value|
-						note.send("#{key}=", value)
-					end
-				end
-				note
-		end
-	end
+      # Factory method to create a Note object from a json string
+      # @param props - JSON string representing a contact
+      # @return Note
+      def self.create(props)
+        note = Note.new
+        if props
+          props.each do |key, value|
+            note.send("#{key}=", value)
+          end
+        end
+        note
+    end
+  end
 end

--- a/lib/constantcontact/components/email_marketing/campaign.rb
+++ b/lib/constantcontact/components/email_marketing/campaign.rb
@@ -5,79 +5,79 @@
 # Copyright (c) 2013 Constant Contact. All rights reserved.
 
 module ConstantContact
-	module Components
-		class Campaign < Component
-			attr_accessor :id, :name, :subject, :status, :from_name, :from_email, :reply_to_email, :template_type,
-										:created_date, :modified_date, :last_run_date, :next_run_date,
-										:is_permission_reminder_enabled, :permission_reminder_text,
-										:is_view_as_webpage_enabled, :view_as_web_page_text, :view_as_web_page_link_text,
-										:greeting_salutations, :greeting_name, :greeting_string, :email_content, :text_content,
-										:message_footer, :tracking_summary, :email_content_format, :style_sheet, :sent_to_contact_lists,
-										:click_through_details, :include_forward_email, :is_visible_in_ui
+  module Components
+    class Campaign < Component
+      attr_accessor :id, :name, :subject, :status, :from_name, :from_email, :reply_to_email, :template_type,
+                    :created_date, :modified_date, :last_run_date, :next_run_date,
+                    :is_permission_reminder_enabled, :permission_reminder_text,
+                    :is_view_as_webpage_enabled, :view_as_web_page_text, :view_as_web_page_link_text,
+                    :greeting_salutations, :greeting_name, :greeting_string, :email_content, :text_content,
+                    :message_footer, :tracking_summary, :email_content_format, :style_sheet, :sent_to_contact_lists,
+                    :click_through_details, :include_forward_email, :is_visible_in_ui
 
 
-			# Factory method to create an EmailCampaign object from an array
-			# @param [Hash] props - hash of properties to create object from
-			# @return [Campaign]
-			def self.create(props)
-				campaign = Campaign.new
-				if props
-					props.each do |key, value|
-						if key == 'message_footer'
-							campaign.message_footer = Components::MessageFooter.create(value)
-						elsif key == 'tracking_summary'
-							campaign.tracking_summary = Components::TrackingSummary.create(value)
-						elsif key == 'sent_to_contact_lists'
-							if value
-								campaign.sent_to_contact_lists = []
-								value.each do |sent_to_contact_list|
-									campaign.sent_to_contact_lists << Components::ContactList.create(sent_to_contact_list)
-								end
-							end
-						elsif key == 'click_through_details'
-							if value
-								campaign.click_through_details = []
-								value.each do |click_through_details|
-									campaign.click_through_details << Components::ClickThroughDetails.create(click_through_details)
-								end
-							end
-						else
-							campaign.send("#{key}=", value)
-						end
-					end
-				end
-				campaign
-			end
+      # Factory method to create an EmailCampaign object from an array
+      # @param [Hash] props - hash of properties to create object from
+      # @return [Campaign]
+      def self.create(props)
+        campaign = Campaign.new
+        if props
+          props.each do |key, value|
+            if key == 'message_footer'
+              campaign.message_footer = Components::MessageFooter.create(value)
+            elsif key == 'tracking_summary'
+              campaign.tracking_summary = Components::TrackingSummary.create(value)
+            elsif key == 'sent_to_contact_lists'
+              if value
+                campaign.sent_to_contact_lists = []
+                value.each do |sent_to_contact_list|
+                  campaign.sent_to_contact_lists << Components::ContactList.create(sent_to_contact_list)
+                end
+              end
+            elsif key == 'click_through_details'
+              if value
+                campaign.click_through_details = []
+                value.each do |click_through_details|
+                  campaign.click_through_details << Components::ClickThroughDetails.create(click_through_details)
+                end
+              end
+            else
+              campaign.send("#{key}=", value)
+            end
+          end
+        end
+        campaign
+      end
 
 
-			# Factory method to create a Campaign object from an array
-			# @param [Hash] props - hash of initial properties to set
-			# @return [Campaign]
-			def self.create_summary(props)
-				campaign = Campaign.new
-				if props
-					props.each do |key, value|
-						campaign.send("#{key}=", value)
-					end
-				end
-				campaign
-			end
+      # Factory method to create a Campaign object from an array
+      # @param [Hash] props - hash of initial properties to set
+      # @return [Campaign]
+      def self.create_summary(props)
+        campaign = Campaign.new
+        if props
+          props.each do |key, value|
+            campaign.send("#{key}=", value)
+          end
+        end
+        campaign
+      end
 
 
-			# Add a contact list to set of lists associated with this email
-			# @param [Mixed] contact_list - Contact list id, or ContactList object
-			def add_list(contact_list)
-				if contact_list.instance_of?(ContactList)
-					list = contact_list
-				elsif contact_list.to_i.to_s == contact_list
-					list = ContactList.new(contact_list)
-				else
-					raise Exceptions::IllegalArgumentException, sprintf(Util::Config.get('errors.id_or_object'), 'ContactList')
-				end
+      # Add a contact list to set of lists associated with this email
+      # @param [Mixed] contact_list - Contact list id, or ContactList object
+      def add_list(contact_list)
+        if contact_list.instance_of?(ContactList)
+          list = contact_list
+        elsif contact_list.to_i.to_s == contact_list
+          list = ContactList.new(contact_list)
+        else
+          raise Exceptions::IllegalArgumentException, sprintf(Util::Config.get('errors.id_or_object'), 'ContactList')
+        end
 
-				@sent_to_contact_lists << list
-			end
+        @sent_to_contact_lists << list
+      end
 
-		end
-	end
+    end
+  end
 end

--- a/lib/constantcontact/components/email_marketing/click_through_details.rb
+++ b/lib/constantcontact/components/email_marketing/click_through_details.rb
@@ -5,24 +5,24 @@
 # Copyright (c) 2013 Constant Contact. All rights reserved.
 
 module ConstantContact
-	module Components
-		class ClickThroughDetails < Component
-			attr_accessor :url, :url_uid, :click_count
+  module Components
+    class ClickThroughDetails < Component
+      attr_accessor :url, :url_uid, :click_count
 
 
-			# Factory method to create an ClickThroughDetails object from an array
-			# @param [Hash] props - hash of properties to create object from
-			# @return [ClickThroughDetails]
-			def self.create(props)
-				click_through_details = ClickThroughDetails.new
-				if props
-					props.each do |key, value|
-						click_through_details.send("#{key}=", value)
-					end
-				end
-				click_through_details
-			end
+      # Factory method to create an ClickThroughDetails object from an array
+      # @param [Hash] props - hash of properties to create object from
+      # @return [ClickThroughDetails]
+      def self.create(props)
+        click_through_details = ClickThroughDetails.new
+        if props
+          props.each do |key, value|
+            click_through_details.send("#{key}=", value)
+          end
+        end
+        click_through_details
+      end
 
-		end
-	end
+    end
+  end
 end

--- a/lib/constantcontact/components/email_marketing/message_footer.rb
+++ b/lib/constantcontact/components/email_marketing/message_footer.rb
@@ -5,26 +5,26 @@
 # Copyright (c) 2013 Constant Contact. All rights reserved.
 
 module ConstantContact
-	module Components
-		class MessageFooter < Component
-			attr_accessor :city, :state, :country, :organization_name, :address_line_1,
-										:address_line_2, :address_line_3, :international_state,
-										:postal_code, :include_forward_email, :forward_email_link_text,
-										:include_subscribe_link, :subscribe_link_text
+  module Components
+    class MessageFooter < Component
+      attr_accessor :city, :state, :country, :organization_name, :address_line_1,
+                    :address_line_2, :address_line_3, :international_state,
+                    :postal_code, :include_forward_email, :forward_email_link_text,
+                    :include_subscribe_link, :subscribe_link_text
 
-			# Factory method to create a MessageFooter object from an array
-			# @param [Hash] props - hash of properties to create object from
-			# @return [MessageFooter]
-			def self.create(props)
-				message_footer = MessageFooter.new
-				if props
-					props.each do |key, value|
-						message_footer.send("#{key}=", value)
-					end
-				end
-				message_footer
-			end
+      # Factory method to create a MessageFooter object from an array
+      # @param [Hash] props - hash of properties to create object from
+      # @return [MessageFooter]
+      def self.create(props)
+        message_footer = MessageFooter.new
+        if props
+          props.each do |key, value|
+            message_footer.send("#{key}=", value)
+          end
+        end
+        message_footer
+      end
 
-		end
-	end
+    end
+  end
 end

--- a/lib/constantcontact/components/email_marketing/schedule.rb
+++ b/lib/constantcontact/components/email_marketing/schedule.rb
@@ -5,25 +5,25 @@
 # Copyright (c) 2013 Constant Contact. All rights reserved.
 
 module ConstantContact
-	module Components
-		class Schedule < Component
-			attr_accessor :id, :scheduled_date
+  module Components
+    class Schedule < Component
+      attr_accessor :id, :scheduled_date
 
 
-			# Factory method to create a Schedule object from an array
-			# @param [Hash] props - hash of properties to create object from
-			# @return [Schedule]
-			def self.create(props)
-				schedule = Schedule.new
-				if props
-					props = props.first if props.is_a?(Array)
-					props.each do |key, value|
-						schedule.send("#{key}=", value)
-					end
-				end
-				schedule
-			end
+      # Factory method to create a Schedule object from an array
+      # @param [Hash] props - hash of properties to create object from
+      # @return [Schedule]
+      def self.create(props)
+        schedule = Schedule.new
+        if props
+          props = props.first if props.is_a?(Array)
+          props.each do |key, value|
+            schedule.send("#{key}=", value)
+          end
+        end
+        schedule
+      end
 
-		end
-	end
+    end
+  end
 end

--- a/lib/constantcontact/components/email_marketing/test_send.rb
+++ b/lib/constantcontact/components/email_marketing/test_send.rb
@@ -5,41 +5,41 @@
 # Copyright (c) 2013 Constant Contact. All rights reserved.
 
 module ConstantContact
-	module Components
-		class TestSend < Component
-			attr_accessor :format, :personal_message, :email_addresses
+  module Components
+    class TestSend < Component
+      attr_accessor :format, :personal_message, :email_addresses
 
 
-			# Factory method to create a TestSend object from an array
-			# @param [Hash] props - hash of properties to create object from
-			# @return [TestSend]
-			def self.create(props)
-				test_send = TestSend.new
-				if props
-					props.each do |key, value|
-						if key == 'email_addresses'
-							if value
-								test_send.email_addresses = []
-								value.each do |email_address|
-									test_send.email_addresses << email_address
-								end
-							end
-						else
-							test_send.send("#{key}=", value)
-						end
-					end
-				end
-				test_send
-			end
+      # Factory method to create a TestSend object from an array
+      # @param [Hash] props - hash of properties to create object from
+      # @return [TestSend]
+      def self.create(props)
+        test_send = TestSend.new
+        if props
+          props.each do |key, value|
+            if key == 'email_addresses'
+              if value
+                test_send.email_addresses = []
+                value.each do |email_address|
+                  test_send.email_addresses << email_address
+                end
+              end
+            else
+              test_send.send("#{key}=", value)
+            end
+          end
+        end
+        test_send
+      end
 
 
-			# Add an email address to the set of addresses to send the test send too
-			# @param [String] email_address
-			def add_email(email_address)
-				@email_addresses = [] if @email_addresses.nil?
-				@email_addresses << email_address
-			end
+      # Add an email address to the set of addresses to send the test send too
+      # @param [String] email_address
+      def add_email(email_address)
+        @email_addresses = [] if @email_addresses.nil?
+        @email_addresses << email_address
+      end
 
-		end
-	end
+    end
+  end
 end

--- a/lib/constantcontact/components/result_set.rb
+++ b/lib/constantcontact/components/result_set.rb
@@ -5,23 +5,23 @@
 # Copyright (c) 2013 Constant Contact. All rights reserved.
 
 module ConstantContact
-	module Components
-		class ResultSet
-			attr_accessor :results, :next
+  module Components
+    class ResultSet
+      attr_accessor :results, :next
 
 
-			# Constructor to create a ResultSet from the results/meta response when performing a get on a collection
-			# @param [Array<Hash>] results - results array from request
-			# @param [Hash] meta - meta hash from request
-			def initialize(results, meta)
-				@results = results
+      # Constructor to create a ResultSet from the results/meta response when performing a get on a collection
+      # @param [Array<Hash>] results - results array from request
+      # @param [Hash] meta - meta hash from request
+      def initialize(results, meta)
+        @results = results
 
-				if meta.has_key?('pagination') and meta['pagination'].has_key?('next_link')
-					next_link = meta['pagination']['next_link']
-					@next = next_link[next_link.index('?'), next_link.length]
-				end
-			end
+        if meta.has_key?('pagination') and meta['pagination'].has_key?('next_link')
+          next_link = meta['pagination']['next_link']
+          @next = next_link[next_link.index('?'), next_link.length]
+        end
+      end
 
-		end
-	end
+    end
+  end
 end

--- a/lib/constantcontact/components/tracking/bounce_activity.rb
+++ b/lib/constantcontact/components/tracking/bounce_activity.rb
@@ -5,25 +5,25 @@
 # Copyright (c) 2013 Constant Contact. All rights reserved.
 
 module ConstantContact
-	module Components
-		class BounceActivity < Component
-			attr_accessor :activity_type, :bounce_code, :bounce_description, :bounce_message, :bounce_date,
-										:contact_id, :email_address, :campaign_id
+  module Components
+    class BounceActivity < Component
+      attr_accessor :activity_type, :bounce_code, :bounce_description, :bounce_message, :bounce_date,
+                    :contact_id, :email_address, :campaign_id
 
 
-			# Factory method to create a BounceActivity object from an array
-			# @param [Hash] props - hash of properties to create object from
-			# @return [BounceActivity]
-			def self.create(props)
-				bounce_activity = BounceActivity.new
-				if props
-					props.each do |key, value|
-						bounce_activity.send("#{key}=", value)
-					end
-				end
-				bounce_activity
-			end
+      # Factory method to create a BounceActivity object from an array
+      # @param [Hash] props - hash of properties to create object from
+      # @return [BounceActivity]
+      def self.create(props)
+        bounce_activity = BounceActivity.new
+        if props
+          props.each do |key, value|
+            bounce_activity.send("#{key}=", value)
+          end
+        end
+        bounce_activity
+      end
 
-		end
-	end
+    end
+  end
 end

--- a/lib/constantcontact/components/tracking/click_activity.rb
+++ b/lib/constantcontact/components/tracking/click_activity.rb
@@ -5,24 +5,24 @@
 # Copyright (c) 2013 Constant Contact. All rights reserved.
 
 module ConstantContact
-	module Components
-		class ClickActivity < Component
-			attr_accessor :activity_type, :campaign_id, :contact_id, :email_address, :link_id, :click_date
+  module Components
+    class ClickActivity < Component
+      attr_accessor :activity_type, :campaign_id, :contact_id, :email_address, :link_id, :click_date
 
 
-			# Factory method to create a ClickActivity object from an array
-			# @param [Hash] props - hash of properties to create object from
-			# @return [ClickActivity]
-			def self.create(props)
-				click_activity = ClickActivity.new
-				if props
-					props.each do |key, value|
-						click_activity.send("#{key}=", value)
-					end
-				end
-				click_activity
-			end
+      # Factory method to create a ClickActivity object from an array
+      # @param [Hash] props - hash of properties to create object from
+      # @return [ClickActivity]
+      def self.create(props)
+        click_activity = ClickActivity.new
+        if props
+          props.each do |key, value|
+            click_activity.send("#{key}=", value)
+          end
+        end
+        click_activity
+      end
 
-		end
-	end
+    end
+  end
 end

--- a/lib/constantcontact/components/tracking/forward_activity.rb
+++ b/lib/constantcontact/components/tracking/forward_activity.rb
@@ -5,24 +5,24 @@
 # Copyright (c) 2013 Constant Contact. All rights reserved.
 
 module ConstantContact
-	module Components
-		class ForwardActivity < Component
-			attr_accessor :activity_type, :campaign_id, :contact_id, :email_address, :forward_date
+  module Components
+    class ForwardActivity < Component
+      attr_accessor :activity_type, :campaign_id, :contact_id, :email_address, :forward_date
 
 
-			# Factory method to create a ForwardActivity object from an array
-			# @param [Hash] props - hash of properties to create object from
-			# @return [ForwardActivity]
-			def self.create(props)
-				forward_activity = ForwardActivity.new
-				if props
-					props.each do |key, value|
-						forward_activity.send("#{key}=", value)
-					end
-				end
-				forward_activity
-			end
+      # Factory method to create a ForwardActivity object from an array
+      # @param [Hash] props - hash of properties to create object from
+      # @return [ForwardActivity]
+      def self.create(props)
+        forward_activity = ForwardActivity.new
+        if props
+          props.each do |key, value|
+            forward_activity.send("#{key}=", value)
+          end
+        end
+        forward_activity
+      end
 
-		end
-	end
+    end
+  end
 end

--- a/lib/constantcontact/components/tracking/open_activity.rb
+++ b/lib/constantcontact/components/tracking/open_activity.rb
@@ -5,24 +5,24 @@
 # Copyright (c) 2013 Constant Contact. All rights reserved.
 
 module ConstantContact
-	module Components
-		class OpenActivity < Component
-			attr_accessor :activity_type, :campaign_id, :email_address, :open_date, :contact_id
+  module Components
+    class OpenActivity < Component
+      attr_accessor :activity_type, :campaign_id, :email_address, :open_date, :contact_id
 
 
-			# Factory method to create an OpenActivity object from an array
-			# @param [Hash] props - hash of properties to create object from
-			# @return [OpenActivity]
-			def self.create(props)
-				open_activity = OpenActivity.new
-				if props
-					props.each do |key, value|
-						open_activity.send("#{key}=", value)
-					end
-				end
-				open_activity
-			end
+      # Factory method to create an OpenActivity object from an array
+      # @param [Hash] props - hash of properties to create object from
+      # @return [OpenActivity]
+      def self.create(props)
+        open_activity = OpenActivity.new
+        if props
+          props.each do |key, value|
+            open_activity.send("#{key}=", value)
+          end
+        end
+        open_activity
+      end
 
-		end
-	end
+    end
+  end
 end

--- a/lib/constantcontact/components/tracking/send_activity.rb
+++ b/lib/constantcontact/components/tracking/send_activity.rb
@@ -5,24 +5,24 @@
 # Copyright (c) 2013 Constant Contact. All rights reserved.
 
 module ConstantContact
-	module Components
-		class SendActivity < Component
-			attr_accessor :activity_type, :campaign_id, :email_address, :contact_id, :send_date
+  module Components
+    class SendActivity < Component
+      attr_accessor :activity_type, :campaign_id, :email_address, :contact_id, :send_date
 
 
-			# Factory method to create a SendActivity object from an array
-			# @param [Hash] props - hash of properties to create object from
-			# @return [SendActivity]
-			def self.create(props)
-				send_activity = SendActivity.new
-				if props
-					props.each do |key, value|
-						send_activity.send("#{key}=", value)
-					end
-				end
-				send_activity
-			end
+      # Factory method to create a SendActivity object from an array
+      # @param [Hash] props - hash of properties to create object from
+      # @return [SendActivity]
+      def self.create(props)
+        send_activity = SendActivity.new
+        if props
+          props.each do |key, value|
+            send_activity.send("#{key}=", value)
+          end
+        end
+        send_activity
+      end
 
-		end
-	end
+    end
+  end
 end

--- a/lib/constantcontact/components/tracking/tracking_activity.rb
+++ b/lib/constantcontact/components/tracking/tracking_activity.rb
@@ -5,23 +5,23 @@
 # Copyright (c) 2013 Constant Contact. All rights reserved.
 
 module ConstantContact
-	module Components
-		class TrackingActivity < Component
-			attr_accessor :results, :next
+  module Components
+    class TrackingActivity < Component
+      attr_accessor :results, :next
 
 
-			# Constructor to create a TrackingActivity from the results/pagination response from getting a set of activities
-			# @param [Array] results - results array from a tracking endpoint
-			# @param [Hash] pagination - pagination hash returned from a tracking endpoint
-			# @return [TrackingActivity] 
-			def initialize(results, pagination)
-				@results = results
+      # Constructor to create a TrackingActivity from the results/pagination response from getting a set of activities
+      # @param [Array] results - results array from a tracking endpoint
+      # @param [Hash] pagination - pagination hash returned from a tracking endpoint
+      # @return [TrackingActivity]
+      def initialize(results, pagination)
+        @results = results
 
-				if (pagination.has_key?('next'))
-					@next = pagination['next'][pagination['next'].index('&next=') + 6, pagination['next'].length]
-				end
-			end
+        if (pagination.has_key?('next'))
+          @next = pagination['next'][pagination['next'].index('&next=') + 6, pagination['next'].length]
+        end
+      end
 
-		end
-	end
+    end
+  end
 end

--- a/lib/constantcontact/components/tracking/tracking_summary.rb
+++ b/lib/constantcontact/components/tracking/tracking_summary.rb
@@ -5,24 +5,24 @@
 # Copyright (c) 2013 Constant Contact. All rights reserved.
 
 module ConstantContact
-	module Components
-		class TrackingSummary < Component
-			attr_accessor :sends, :opens, :clicks, :forwards, :unsubscribes, :bounces, :contact_id
+  module Components
+    class TrackingSummary < Component
+      attr_accessor :sends, :opens, :clicks, :forwards, :unsubscribes, :bounces, :contact_id
 
 
-			# Factory method to create a TrackingSummary object from an array
-			# @param [Hash] props - array of properties to create object from
-			# @return [TrackingSummary]
-			def self.create(props)
-				tracking_summary = TrackingSummary.new
-				if props
-					props.each do |key, value|
-						tracking_summary.send("#{key}=", value)
-					end
-				end
-				tracking_summary
-			end
+      # Factory method to create a TrackingSummary object from an array
+      # @param [Hash] props - array of properties to create object from
+      # @return [TrackingSummary]
+      def self.create(props)
+        tracking_summary = TrackingSummary.new
+        if props
+          props.each do |key, value|
+            tracking_summary.send("#{key}=", value)
+          end
+        end
+        tracking_summary
+      end
 
-		end
-	end
+    end
+  end
 end

--- a/lib/constantcontact/components/tracking/unsubscribe_activity.rb
+++ b/lib/constantcontact/components/tracking/unsubscribe_activity.rb
@@ -5,25 +5,25 @@
 # Copyright (c) 2013 Constant Contact. All rights reserved.
 
 module ConstantContact
-	module Components
-		class UnsubscribeActivity < Component
-			attr_accessor :activity_type, :campaign_id, :contact_id, :email_address, :unsubscribe_date,
-										:unsubscribe_source, :unsubscribe_reason
+  module Components
+    class UnsubscribeActivity < Component
+      attr_accessor :activity_type, :campaign_id, :contact_id, :email_address, :unsubscribe_date,
+                    :unsubscribe_source, :unsubscribe_reason
 
 
-			# Factory method to create an UnsubscribeActivity object from an array
-			# @param [Hash] props - hash of properties to create object from
-			# @return [UnsubscribeActivity]
-			def self.create(props)
-				unsubscribe_activity = UnsubscribeActivity.new
-				if props
-					props.each do |key, value|
-						unsubscribe_activity.send("#{key}=", value)
-					end
-				end
-				unsubscribe_activity
-			end
+      # Factory method to create an UnsubscribeActivity object from an array
+      # @param [Hash] props - hash of properties to create object from
+      # @return [UnsubscribeActivity]
+      def self.create(props)
+        unsubscribe_activity = UnsubscribeActivity.new
+        if props
+          props.each do |key, value|
+            unsubscribe_activity.send("#{key}=", value)
+          end
+        end
+        unsubscribe_activity
+      end
 
-		end
-	end
+    end
+  end
 end

--- a/lib/constantcontact/exceptions/ctct_exception.rb
+++ b/lib/constantcontact/exceptions/ctct_exception.rb
@@ -5,21 +5,21 @@
 # Copyright (c) 2013 Constant Contact. All rights reserved.
 
 module ConstantContact
-	module Exceptions
-		class CtctException < Exception
-			attr_accessor :errors
+  module Exceptions
+    class CtctException < Exception
+      attr_accessor :errors
 
-			# Setter
-			# @param [Array<String>] errors
-			def set_errors(errors)
-				@errors = errors
-			end
+      # Setter
+      # @param [Array<String>] errors
+      def set_errors(errors)
+        @errors = errors
+      end
 
-			# Getter
-			# @return [Array<String>]
-			def get_errors
-				@errors
-			end
-		end
-	end
+      # Getter
+      # @return [Array<String>]
+      def get_errors
+        @errors
+      end
+    end
+  end
 end

--- a/lib/constantcontact/exceptions/illegal_argument_exception.rb
+++ b/lib/constantcontact/exceptions/illegal_argument_exception.rb
@@ -5,7 +5,7 @@
 # Copyright (c) 2013 Constant Contact. All rights reserved.
 
 module ConstantContact
-	module Exceptions
-		class IllegalArgumentException < Exception; end
-	end
+  module Exceptions
+    class IllegalArgumentException < Exception; end
+  end
 end

--- a/lib/constantcontact/exceptions/oauth2_exception.rb
+++ b/lib/constantcontact/exceptions/oauth2_exception.rb
@@ -5,7 +5,7 @@
 # Copyright (c) 2013 Constant Contact. All rights reserved.
 
 module ConstantContact
-	module Exceptions
-		class OAuth2Exception < Exception; end
-	end
+  module Exceptions
+    class OAuth2Exception < Exception; end
+  end
 end

--- a/lib/constantcontact/services/account_service.rb
+++ b/lib/constantcontact/services/account_service.rb
@@ -5,25 +5,25 @@
 # Copyright (c) 2013 Constant Contact. All rights reserved.
 
 module ConstantContact
-	module Services
-		class AccountService < BaseService
-			class << self
+  module Services
+    class AccountService < BaseService
+      class << self
 
-				# Get the verified emails from account
-				# @param [String] access_token - Constant Contact OAuth2 access token
-				# @return [Array<VerifiedEmailAddress>]
-				def get_verified_email_addresses(access_token)
-					url = Util::Config.get('endpoints.base_url') + Util::Config.get('endpoints.account_verified_addresses')
-					url = build_url(url)
-					response = RestClient.get(url, get_headers(access_token))
-					email_addresses = []
-					JSON.parse(response.body).each do |email_address|
-						email_addresses << Components::VerifiedEmailAddress.create(email_address)
-					end
-					email_addresses
-				end
+        # Get the verified emails from account
+        # @param [String] access_token - Constant Contact OAuth2 access token
+        # @return [Array<VerifiedEmailAddress>]
+        def get_verified_email_addresses(access_token)
+          url = Util::Config.get('endpoints.base_url') + Util::Config.get('endpoints.account_verified_addresses')
+          url = build_url(url)
+          response = RestClient.get(url, get_headers(access_token))
+          email_addresses = []
+          JSON.parse(response.body).each do |email_address|
+            email_addresses << Components::VerifiedEmailAddress.create(email_address)
+          end
+          email_addresses
+        end
 
-			end
-		end
-	end
+      end
+    end
+  end
 end

--- a/lib/constantcontact/services/activity_service.rb
+++ b/lib/constantcontact/services/activity_service.rb
@@ -5,103 +5,103 @@
 # Copyright (c) 2013 Constant Contact. All rights reserved.
 
 module ConstantContact
-	module Services
-		class ActivityService < BaseService
-			class << self
+  module Services
+    class ActivityService < BaseService
+      class << self
 
-				# Get a set of activities
-				# @param [String] access_token
-				# @return [Array<Activity>]
-				def get_activities(access_token)
-					url = Util::Config.get('endpoints.base_url') + Util::Config.get('endpoints.activities')
-					url = build_url(url)
-					response = RestClient.get(url, get_headers(access_token))
+        # Get a set of activities
+        # @param [String] access_token
+        # @return [Array<Activity>]
+        def get_activities(access_token)
+          url = Util::Config.get('endpoints.base_url') + Util::Config.get('endpoints.activities')
+          url = build_url(url)
+          response = RestClient.get(url, get_headers(access_token))
 
-					activities = []
-					JSON.parse(response.body).each do |activity|
-						activities << Components::Activity.create(activity)
-					end
+          activities = []
+          JSON.parse(response.body).each do |activity|
+            activities << Components::Activity.create(activity)
+          end
 
-					activities
-				end
-
-
-				# Get an array of activities
-				# @param [String] access_token - Constant Contact OAuth2 access token
-				# @param [String] activity_id - Activity id
-				# @return [Activity]
-				def get_activity(access_token, activity_id)
-					url = Util::Config.get('endpoints.base_url') + 
-								sprintf(Util::Config.get('endpoints.activity'), activity_id)
-					url = build_url(url)
-					response = RestClient.get(url, get_headers(access_token))
-					Components::Activity.create(JSON.parse(response.body))
-				end
+          activities
+        end
 
 
-				# Create an Add Contacts Activity
-				# @param [String] access_token - Constant Contact OAuth2 access token
-				# @param [AddContacts] add_contacts
-				# @return [Activity]
-				def create_add_contacts_activity(access_token, add_contacts)
-					url = Util::Config.get('endpoints.base_url') + 
-								Util::Config.get('endpoints.add_contacts_activity')
-					url = build_url(url)
-					payload = add_contacts.to_json
-					response = RestClient.post(url, payload, get_headers(access_token))
-					Components::Activity.create(JSON.parse(response.body))
-				end
+        # Get an array of activities
+        # @param [String] access_token - Constant Contact OAuth2 access token
+        # @param [String] activity_id - Activity id
+        # @return [Activity]
+        def get_activity(access_token, activity_id)
+          url = Util::Config.get('endpoints.base_url') +
+                sprintf(Util::Config.get('endpoints.activity'), activity_id)
+          url = build_url(url)
+          response = RestClient.get(url, get_headers(access_token))
+          Components::Activity.create(JSON.parse(response.body))
+        end
 
 
-				# Create a Clear Lists Activity
-				# @param [String] access_token - Constant Contact OAuth2 access token
-				# @param [Array<lists>] lists - array of list id's to be cleared
-				# @return [Activity]
-				def add_clear_lists_activity(access_token, lists)
-					url = Util::Config.get('endpoints.base_url') + 
-								Util::Config.get('endpoints.clear_lists_activity')
-					url = build_url(url)
-					payload = {'lists' => lists}.to_json
-					response = RestClient.post(url, payload, get_headers(access_token))
-					Components::Activity.create(JSON.parse(response.body))
-				end
+        # Create an Add Contacts Activity
+        # @param [String] access_token - Constant Contact OAuth2 access token
+        # @param [AddContacts] add_contacts
+        # @return [Activity]
+        def create_add_contacts_activity(access_token, add_contacts)
+          url = Util::Config.get('endpoints.base_url') +
+                Util::Config.get('endpoints.add_contacts_activity')
+          url = build_url(url)
+          payload = add_contacts.to_json
+          response = RestClient.post(url, payload, get_headers(access_token))
+          Components::Activity.create(JSON.parse(response.body))
+        end
 
 
-				# Create an Export Contacts Activity
-				# @param [String] access_token - Constant Contact OAuth2 access token
-				# @param [ExportContacts] export_contacts
-				# @return [Activity]
-				def add_export_contacts_activity(access_token, export_contacts)
-					url = Util::Config.get('endpoints.base_url') + 
-								Util::Config.get('endpoints.export_contacts_activity')
-					url = build_url(url)
-					payload = export_contacts.to_json
-					response = RestClient.post(url, payload, get_headers(access_token))
-					Components::Activity.create(JSON.parse(response.body))
-				end
+        # Create a Clear Lists Activity
+        # @param [String] access_token - Constant Contact OAuth2 access token
+        # @param [Array<lists>] lists - array of list id's to be cleared
+        # @return [Activity]
+        def add_clear_lists_activity(access_token, lists)
+          url = Util::Config.get('endpoints.base_url') +
+                Util::Config.get('endpoints.clear_lists_activity')
+          url = build_url(url)
+          payload = {'lists' => lists}.to_json
+          response = RestClient.post(url, payload, get_headers(access_token))
+          Components::Activity.create(JSON.parse(response.body))
+        end
 
 
-				# Create a Remove Contacts From Lists Activity
-				# @param [String] access_token - Constant Contact OAuth2 access token
-				# @param [<Array>EmailAddress] email_addresses
-				# @param [<Array>RemoveFromLists] lists
-				# @return [Activity]
-				def add_remove_contacts_from_lists_activity(access_token, email_addresses, lists)
-					url = Util::Config.get('endpoints.base_url') + 
-								Util::Config.get('endpoints.remove_from_lists_activity')
-					url = build_url(url)
+        # Create an Export Contacts Activity
+        # @param [String] access_token - Constant Contact OAuth2 access token
+        # @param [ExportContacts] export_contacts
+        # @return [Activity]
+        def add_export_contacts_activity(access_token, export_contacts)
+          url = Util::Config.get('endpoints.base_url') +
+                Util::Config.get('endpoints.export_contacts_activity')
+          url = build_url(url)
+          payload = export_contacts.to_json
+          response = RestClient.post(url, payload, get_headers(access_token))
+          Components::Activity.create(JSON.parse(response.body))
+        end
 
-					payload = { 'import_data' => [], 'lists' => lists }
-					email_addresses.each do |email_address|
-						payload['import_data'] << { 'email_addresses' => [email_address] }
-					end
-					payload = payload.to_json
 
-					response = RestClient.post(url, payload, get_headers(access_token))
-					Components::Activity.create(JSON.parse(response.body))
-				end
+        # Create a Remove Contacts From Lists Activity
+        # @param [String] access_token - Constant Contact OAuth2 access token
+        # @param [<Array>EmailAddress] email_addresses
+        # @param [<Array>RemoveFromLists] lists
+        # @return [Activity]
+        def add_remove_contacts_from_lists_activity(access_token, email_addresses, lists)
+          url = Util::Config.get('endpoints.base_url') +
+                Util::Config.get('endpoints.remove_from_lists_activity')
+          url = build_url(url)
 
-			end
-		end
-	end
+          payload = { 'import_data' => [], 'lists' => lists }
+          email_addresses.each do |email_address|
+            payload['import_data'] << { 'email_addresses' => [email_address] }
+          end
+          payload = payload.to_json
+
+          response = RestClient.post(url, payload, get_headers(access_token))
+          Components::Activity.create(JSON.parse(response.body))
+        end
+
+      end
+    end
+  end
 end

--- a/lib/constantcontact/services/base_service.rb
+++ b/lib/constantcontact/services/base_service.rb
@@ -5,33 +5,33 @@
 # Copyright (c) 2013 Constant Contact. All rights reserved.
 
 module ConstantContact
-	module Services
-		class BaseService
-			class << self
-				attr_accessor :api_key
+  module Services
+    class BaseService
+      class << self
+        attr_accessor :api_key
 
-				protected
+        protected
 
-				# Helper function to return required headers for making an http request with constant contact
-				# @param [String] access_token - OAuth2 access token to be placed into the Authorization header
-				# @return [Hash] - authorization headers
-				def get_headers(access_token)
-					{
-						:content_type   => 'application/json',
-						:accept         => 'application/json',
-						:authorization  => "Bearer #{access_token}"
-					}
-				end
+        # Helper function to return required headers for making an http request with constant contact
+        # @param [String] access_token - OAuth2 access token to be placed into the Authorization header
+        # @return [Hash] - authorization headers
+        def get_headers(access_token)
+          {
+            :content_type   => 'application/json',
+            :accept         => 'application/json',
+            :authorization  => "Bearer #{access_token}"
+          }
+        end
 
 
-				# Build a url from the base url and query parameters hash
-				def build_url(url, params = nil)
-					params = {} if !params
-					params['api_key'] = BaseService.api_key
-					url += '?' + Util::Helpers.http_build_query(params)
-				end
+        # Build a url from the base url and query parameters hash
+        def build_url(url, params = nil)
+          params = {} if !params
+          params['api_key'] = BaseService.api_key
+          url += '?' + Util::Helpers.http_build_query(params)
+        end
 
-			end
-		end
-	end
+      end
+    end
+  end
 end

--- a/lib/constantcontact/services/campaign_schedule_service.rb
+++ b/lib/constantcontact/services/campaign_schedule_service.rb
@@ -5,103 +5,103 @@
 # Copyright (c) 2013 Constant Contact. All rights reserved.
 
 module ConstantContact
-	module Services
-		class CampaignScheduleService < BaseService
-			class << self
+  module Services
+    class CampaignScheduleService < BaseService
+      class << self
 
-				# Create a new schedule for a campaign
-				# @param [String] access_token - Constant Contact OAuth2 access token
-				# @param [Integer] campaign_id - Campaign id to be scheduled
-				# @param [Schedule] schedule - Schedule to be created
-				# @return [Schedule]
-				def add_schedule(access_token, campaign_id, schedule)
-					url = Util::Config.get('endpoints.base_url') + 
-								sprintf(Util::Config.get('endpoints.campaign_schedules'), campaign_id)
-					url = build_url(url)
-					payload = schedule.to_json
-					response = RestClient.post(url, payload, get_headers(access_token))
-					Components::Schedule.create(JSON.parse(response.body))
-				end
-
-
-				# Get a list of schedules for a campaign
-				# @param [String] access_token - Constant Contact OAuth2 access token
-				# @param [Integer] campaign_id - Campaign id to be scheduled
-				# @return [Array<Schedule>]
-				def get_schedules(access_token, campaign_id)
-					url = Util::Config.get('endpoints.base_url') + 
-								sprintf(Util::Config.get('endpoints.campaign_schedules'), campaign_id)
-					url = build_url(url)
-					response = RestClient.get(url, get_headers(access_token))
-					body = JSON.parse(response.body)
-
-					schedules = []
-					body.each do |schedule|
-						schedules << Components::Schedule.create(schedule)
-					end
-
-					schedules
-				end
+        # Create a new schedule for a campaign
+        # @param [String] access_token - Constant Contact OAuth2 access token
+        # @param [Integer] campaign_id - Campaign id to be scheduled
+        # @param [Schedule] schedule - Schedule to be created
+        # @return [Schedule]
+        def add_schedule(access_token, campaign_id, schedule)
+          url = Util::Config.get('endpoints.base_url') +
+                sprintf(Util::Config.get('endpoints.campaign_schedules'), campaign_id)
+          url = build_url(url)
+          payload = schedule.to_json
+          response = RestClient.post(url, payload, get_headers(access_token))
+          Components::Schedule.create(JSON.parse(response.body))
+        end
 
 
-				# Get a specific schedule for a campaign
-				# @param [String] access_token - Constant Contact OAuth2 access token
-				# @param [Integer] campaign_id - Campaign id to get a schedule for
-				# @param [Integer] schedule_id - Schedule id to retrieve
-				# @return [Schedule]
-				def get_schedule(access_token, campaign_id, schedule_id)
-					url = Util::Config.get('endpoints.base_url') + 
-								sprintf(Util::Config.get('endpoints.campaign_schedule'), campaign_id, schedule_id)
-					url = build_url(url)
-					response = RestClient.get(url, get_headers(access_token))
-					Components::Schedule.create(JSON.parse(response.body))
-				end
+        # Get a list of schedules for a campaign
+        # @param [String] access_token - Constant Contact OAuth2 access token
+        # @param [Integer] campaign_id - Campaign id to be scheduled
+        # @return [Array<Schedule>]
+        def get_schedules(access_token, campaign_id)
+          url = Util::Config.get('endpoints.base_url') +
+                sprintf(Util::Config.get('endpoints.campaign_schedules'), campaign_id)
+          url = build_url(url)
+          response = RestClient.get(url, get_headers(access_token))
+          body = JSON.parse(response.body)
+
+          schedules = []
+          body.each do |schedule|
+            schedules << Components::Schedule.create(schedule)
+          end
+
+          schedules
+        end
 
 
-				# Delete a specific schedule for a campaign
-				# @param [String] access_token - Constant Contact OAuth2 access token
-				# @param [Integer] campaign_id - Campaign id to delete a schedule for
-				# @param [Integer] schedule_id - Schedule id to delete
-				# @return [Boolean]
-				def delete_schedule(access_token, campaign_id, schedule_id)
-					url = Util::Config.get('endpoints.base_url') + 
-								sprintf(Util::Config.get('endpoints.campaign_schedule'), campaign_id, schedule_id)
-					url = build_url(url)
-					response = RestClient.delete(url, get_headers(access_token))
-					response.code == 204
-				end
+        # Get a specific schedule for a campaign
+        # @param [String] access_token - Constant Contact OAuth2 access token
+        # @param [Integer] campaign_id - Campaign id to get a schedule for
+        # @param [Integer] schedule_id - Schedule id to retrieve
+        # @return [Schedule]
+        def get_schedule(access_token, campaign_id, schedule_id)
+          url = Util::Config.get('endpoints.base_url') +
+                sprintf(Util::Config.get('endpoints.campaign_schedule'), campaign_id, schedule_id)
+          url = build_url(url)
+          response = RestClient.get(url, get_headers(access_token))
+          Components::Schedule.create(JSON.parse(response.body))
+        end
 
 
-				# Update a specific schedule for a campaign
-				# @param [String] access_token - Constant Contact OAuth2 access token
-				# @param [Integer] campaign_id - Campaign id to be scheduled
-				# @param [Schedule] schedule - Schedule to retrieve 
-				# @return [Schedule]
-				def update_schedule(access_token, campaign_id, schedule)
-					url = Util::Config.get('endpoints.base_url') + 
-								sprintf(Util::Config.get('endpoints.campaign_schedule'), campaign_id, schedule.id)
-					url = build_url(url)
-					payload = schedule.to_json
-					response = RestClient.put(url, payload, get_headers(access_token))
-					Components::Schedule.create(JSON.parse(response.body))
-				end
+        # Delete a specific schedule for a campaign
+        # @param [String] access_token - Constant Contact OAuth2 access token
+        # @param [Integer] campaign_id - Campaign id to delete a schedule for
+        # @param [Integer] schedule_id - Schedule id to delete
+        # @return [Boolean]
+        def delete_schedule(access_token, campaign_id, schedule_id)
+          url = Util::Config.get('endpoints.base_url') +
+                sprintf(Util::Config.get('endpoints.campaign_schedule'), campaign_id, schedule_id)
+          url = build_url(url)
+          response = RestClient.delete(url, get_headers(access_token))
+          response.code == 204
+        end
 
 
-				# Send a test send of a campaign
-				# @param [String] access_token - Constant Contact OAuth2 access token
-				# @param [Integer] campaign_id - Id of campaign to send test of
-				# @param [TestSend] test_send - Test send details
-				# @return [TestSend]
-				def send_test(access_token, campaign_id, test_send)
-					url = Util::Config.get('endpoints.base_url') + 
-								sprintf(Util::Config.get('endpoints.campaign_test_sends'), campaign_id)
-					url = build_url(url)
-					payload = test_send.to_json
-					response = RestClient.post(url, payload, get_headers(access_token))
-					Components::TestSend.create(JSON.parse(response.body))
-				end
+        # Update a specific schedule for a campaign
+        # @param [String] access_token - Constant Contact OAuth2 access token
+        # @param [Integer] campaign_id - Campaign id to be scheduled
+        # @param [Schedule] schedule - Schedule to retrieve
+        # @return [Schedule]
+        def update_schedule(access_token, campaign_id, schedule)
+          url = Util::Config.get('endpoints.base_url') +
+                sprintf(Util::Config.get('endpoints.campaign_schedule'), campaign_id, schedule.id)
+          url = build_url(url)
+          payload = schedule.to_json
+          response = RestClient.put(url, payload, get_headers(access_token))
+          Components::Schedule.create(JSON.parse(response.body))
+        end
 
-			end
-		end
-	end
+
+        # Send a test send of a campaign
+        # @param [String] access_token - Constant Contact OAuth2 access token
+        # @param [Integer] campaign_id - Id of campaign to send test of
+        # @param [TestSend] test_send - Test send details
+        # @return [TestSend]
+        def send_test(access_token, campaign_id, test_send)
+          url = Util::Config.get('endpoints.base_url') +
+                sprintf(Util::Config.get('endpoints.campaign_test_sends'), campaign_id)
+          url = build_url(url)
+          payload = test_send.to_json
+          response = RestClient.post(url, payload, get_headers(access_token))
+          Components::TestSend.create(JSON.parse(response.body))
+        end
+
+      end
+    end
+  end
 end

--- a/lib/constantcontact/services/campaign_tracking_service.rb
+++ b/lib/constantcontact/services/campaign_tracking_service.rb
@@ -5,155 +5,155 @@
 # Copyright (c) 2013 Constant Contact. All rights reserved.
 
 module ConstantContact
-	module Services
-		class CampaignTrackingService < BaseService
-			class << self
+  module Services
+    class CampaignTrackingService < BaseService
+      class << self
 
-				# Get a result set of bounces for a given campaign
-				# @param [String] access_token - Constant Contact OAuth2 access token
-				# @param [String] campaign_id - Campaign id
-				# @param [Hash] param - query parameters to be appended to request
-				# @return [ResultSet<BounceActivity>] - Containing a results array of BounceActivity
-				def get_bounces(access_token, campaign_id, param = nil)
-					url = Util::Config.get('endpoints.base_url') +
-								sprintf(Util::Config.get('endpoints.campaign_tracking_bounces'), campaign_id)
-					url = build_url(url, param)
+        # Get a result set of bounces for a given campaign
+        # @param [String] access_token - Constant Contact OAuth2 access token
+        # @param [String] campaign_id - Campaign id
+        # @param [Hash] param - query parameters to be appended to request
+        # @return [ResultSet<BounceActivity>] - Containing a results array of BounceActivity
+        def get_bounces(access_token, campaign_id, param = nil)
+          url = Util::Config.get('endpoints.base_url') +
+                sprintf(Util::Config.get('endpoints.campaign_tracking_bounces'), campaign_id)
+          url = build_url(url, param)
 
-					response = RestClient.get(url, get_headers(access_token))
-					body = JSON.parse(response.body)
+          response = RestClient.get(url, get_headers(access_token))
+          body = JSON.parse(response.body)
 
-					bounces = []
-					body['results'].each do |bounce_activity|
-						bounces << Components::BounceActivity.create(bounce_activity)
-					end
+          bounces = []
+          body['results'].each do |bounce_activity|
+            bounces << Components::BounceActivity.create(bounce_activity)
+          end
 
-					Components::ResultSet.new(bounces, body['meta'])
-				end
-
-
-				# Get clicks for a given campaign
-				# @param [String] access_token - Constant Contact OAuth2 access token
-				# @param [String] campaign_id - Campaign id
-				# @param [Hash] param - query parameters to be appended to request
-				# @return [ResultSet<ClickActivity>] - Containing a results array of ClickActivity
-				def get_clicks(access_token, campaign_id, param = nil)
-					url = Util::Config.get('endpoints.base_url') +
-								sprintf(Util::Config.get('endpoints.campaign_tracking_clicks'), campaign_id)
-					url = build_url(url, param)
-
-					response = RestClient.get(url, get_headers(access_token))
-					body = JSON.parse(response.body)
-
-					clicks = []
-					body['results'].each do |click_activity|
-						clicks << Components::ClickActivity.create(click_activity)
-					end
-
-					Components::ResultSet.new(clicks, body['meta'])
-				end
+          Components::ResultSet.new(bounces, body['meta'])
+        end
 
 
-				# Get forwards for a given campaign
-				# @param [String] access_token - Constant Contact OAuth2 access token
-				# @param [String] campaign_id - Campaign id
-				# @param [Hash] param - query parameters to be appended to request
-				# @return [ResultSet<ForwardActivity>] - Containing a results array of ForwardActivity
-				def get_forwards(access_token, campaign_id, param = nil)
-					url = Util::Config.get('endpoints.base_url') +
-								sprintf(Util::Config.get('endpoints.campaign_tracking_forwards'), campaign_id)
-					url = build_url(url, param)
+        # Get clicks for a given campaign
+        # @param [String] access_token - Constant Contact OAuth2 access token
+        # @param [String] campaign_id - Campaign id
+        # @param [Hash] param - query parameters to be appended to request
+        # @return [ResultSet<ClickActivity>] - Containing a results array of ClickActivity
+        def get_clicks(access_token, campaign_id, param = nil)
+          url = Util::Config.get('endpoints.base_url') +
+                sprintf(Util::Config.get('endpoints.campaign_tracking_clicks'), campaign_id)
+          url = build_url(url, param)
 
-					response = RestClient.get(url, get_headers(access_token))
-					body = JSON.parse(response.body)
+          response = RestClient.get(url, get_headers(access_token))
+          body = JSON.parse(response.body)
 
-					forwards = []
-					body['results'].each do |forward_activity|
-						forwards << Components::ForwardActivity.create(forward_activity)
-					end
+          clicks = []
+          body['results'].each do |click_activity|
+            clicks << Components::ClickActivity.create(click_activity)
+          end
 
-					Components::ResultSet.new(forwards, body['meta'])
-				end
-
-
-				# Get opens for a given campaign
-				# @param [String] access_token - Constant Contact OAuth2 access token
-				# @param [String] campaign_id - Campaign id
-				# @param [Hash] param - query parameters to be appended to request
-				# @return [ResultSet<OpenActivity>] - Containing a results array of OpenActivity
-				def get_opens(access_token, campaign_id, param = nil)
-					url = Util::Config.get('endpoints.base_url') +
-								sprintf(Util::Config.get('endpoints.campaign_tracking_opens'), campaign_id)
-					url = build_url(url, param)
-
-					response = RestClient.get(url, get_headers(access_token))
-					body = JSON.parse(response.body)
-
-					opens = []
-					body['results'].each do |open_activity|
-						opens << Components::OpenActivity.create(open_activity)
-					end
-
-					Components::ResultSet.new(opens, body['meta'])
-				end
+          Components::ResultSet.new(clicks, body['meta'])
+        end
 
 
-				# Get sends for a given campaign
-				# @param [String] access_token - Constant Contact OAuth2 access token
-				# @param [String] campaign_id - Campaign id
-				# @param [Hash] param - query parameters to be appended to request
-				# @return [ResultSet<SendActivity>] - Containing a results array of SendActivity
-				def get_sends(access_token, campaign_id, param = nil)
-					url = Util::Config.get('endpoints.base_url') +
-								sprintf(Util::Config.get('endpoints.campaign_tracking_sends'), campaign_id)
-					url = build_url(url, param)
+        # Get forwards for a given campaign
+        # @param [String] access_token - Constant Contact OAuth2 access token
+        # @param [String] campaign_id - Campaign id
+        # @param [Hash] param - query parameters to be appended to request
+        # @return [ResultSet<ForwardActivity>] - Containing a results array of ForwardActivity
+        def get_forwards(access_token, campaign_id, param = nil)
+          url = Util::Config.get('endpoints.base_url') +
+                sprintf(Util::Config.get('endpoints.campaign_tracking_forwards'), campaign_id)
+          url = build_url(url, param)
 
-					response = RestClient.get(url, get_headers(access_token))
-					body = JSON.parse(response.body)
+          response = RestClient.get(url, get_headers(access_token))
+          body = JSON.parse(response.body)
 
-					sends = []
-					body['results'].each do |send_activity|
-						sends << Components::SendActivity.create(send_activity)
-					end
+          forwards = []
+          body['results'].each do |forward_activity|
+            forwards << Components::ForwardActivity.create(forward_activity)
+          end
 
-					Components::ResultSet.new(sends, body['meta'])
-				end
-
-
-				# Get unsubscribes for a given campaign
-				# @param [String] access_token - Constant Contact OAuth2 access token
-				# @param [String] campaign_id - Campaign id
-				# @param [Hash] param - query params to be appended to request
-				# @return [ResultSet<UnsubscribeActivity>] - Containing a results array of UnsubscribeActivity
-				def get_unsubscribes(access_token, campaign_id, param = nil)
-					url = Util::Config.get('endpoints.base_url') +
-								sprintf(Util::Config.get('endpoints.campaign_tracking_unsubscribes'), campaign_id)
-					url = build_url(url, param)
-
-					response = RestClient.get(url, get_headers(access_token))
-					body = JSON.parse(response.body)
-
-					unsubscribes = []
-					body['results'].each do |unsubscribe_activity|
-						unsubscribes[] = Components::UnsubscribeActivity.create(unsubscribe_activity)
-					end
-
-					Components::ResultSet.new(unsubscribes, body['meta'])
-				end
+          Components::ResultSet.new(forwards, body['meta'])
+        end
 
 
-				# Get a summary of reporting data for a given campaign
-				# @param [String] access_token - Constant Contact OAuth2 access token
-				# @param [Integer] campaign_id - Campaign id
-				# @return [TrackingSummary]
-				def get_summary(access_token, campaign_id)
-					url = Util::Config.get('endpoints.base_url') +
-								sprintf(Util::Config.get('endpoints.campaign_tracking_summary'), campaign_id)
-					url = build_url(url)
-					response = RestClient.get(url, get_headers(access_token))
-					Components::TrackingSummary.create(JSON.parse(response.body))
-				end
+        # Get opens for a given campaign
+        # @param [String] access_token - Constant Contact OAuth2 access token
+        # @param [String] campaign_id - Campaign id
+        # @param [Hash] param - query parameters to be appended to request
+        # @return [ResultSet<OpenActivity>] - Containing a results array of OpenActivity
+        def get_opens(access_token, campaign_id, param = nil)
+          url = Util::Config.get('endpoints.base_url') +
+                sprintf(Util::Config.get('endpoints.campaign_tracking_opens'), campaign_id)
+          url = build_url(url, param)
 
-			end
-		end
-	end
+          response = RestClient.get(url, get_headers(access_token))
+          body = JSON.parse(response.body)
+
+          opens = []
+          body['results'].each do |open_activity|
+            opens << Components::OpenActivity.create(open_activity)
+          end
+
+          Components::ResultSet.new(opens, body['meta'])
+        end
+
+
+        # Get sends for a given campaign
+        # @param [String] access_token - Constant Contact OAuth2 access token
+        # @param [String] campaign_id - Campaign id
+        # @param [Hash] param - query parameters to be appended to request
+        # @return [ResultSet<SendActivity>] - Containing a results array of SendActivity
+        def get_sends(access_token, campaign_id, param = nil)
+          url = Util::Config.get('endpoints.base_url') +
+                sprintf(Util::Config.get('endpoints.campaign_tracking_sends'), campaign_id)
+          url = build_url(url, param)
+
+          response = RestClient.get(url, get_headers(access_token))
+          body = JSON.parse(response.body)
+
+          sends = []
+          body['results'].each do |send_activity|
+            sends << Components::SendActivity.create(send_activity)
+          end
+
+          Components::ResultSet.new(sends, body['meta'])
+        end
+
+
+        # Get unsubscribes for a given campaign
+        # @param [String] access_token - Constant Contact OAuth2 access token
+        # @param [String] campaign_id - Campaign id
+        # @param [Hash] param - query params to be appended to request
+        # @return [ResultSet<UnsubscribeActivity>] - Containing a results array of UnsubscribeActivity
+        def get_unsubscribes(access_token, campaign_id, param = nil)
+          url = Util::Config.get('endpoints.base_url') +
+                sprintf(Util::Config.get('endpoints.campaign_tracking_unsubscribes'), campaign_id)
+          url = build_url(url, param)
+
+          response = RestClient.get(url, get_headers(access_token))
+          body = JSON.parse(response.body)
+
+          unsubscribes = []
+          body['results'].each do |unsubscribe_activity|
+            unsubscribes[] = Components::UnsubscribeActivity.create(unsubscribe_activity)
+          end
+
+          Components::ResultSet.new(unsubscribes, body['meta'])
+        end
+
+
+        # Get a summary of reporting data for a given campaign
+        # @param [String] access_token - Constant Contact OAuth2 access token
+        # @param [Integer] campaign_id - Campaign id
+        # @return [TrackingSummary]
+        def get_summary(access_token, campaign_id)
+          url = Util::Config.get('endpoints.base_url') +
+                sprintf(Util::Config.get('endpoints.campaign_tracking_summary'), campaign_id)
+          url = build_url(url)
+          response = RestClient.get(url, get_headers(access_token))
+          Components::TrackingSummary.create(JSON.parse(response.body))
+        end
+
+      end
+    end
+  end
 end

--- a/lib/constantcontact/services/contact_service.rb
+++ b/lib/constantcontact/services/contact_service.rb
@@ -5,110 +5,110 @@
 # Copyright (c) 2013 Constant Contact. All rights reserved.
 
 module ConstantContact
-	module Services
-		class ContactService < BaseService
-			class << self
+  module Services
+    class ContactService < BaseService
+      class << self
 
-				# Get an array of contacts
-				# @param [String] access_token - Constant Contact OAuth2 access token
-				# @param [Hash] param - query parameters to be appended to the request
-				# @return [ResultSet<Contact>]
-				def get_contacts(access_token, param = nil)
-					url = Util::Config.get('endpoints.base_url') + Util::Config.get('endpoints.contacts')
-					url = build_url(url, param)
+        # Get an array of contacts
+        # @param [String] access_token - Constant Contact OAuth2 access token
+        # @param [Hash] param - query parameters to be appended to the request
+        # @return [ResultSet<Contact>]
+        def get_contacts(access_token, param = nil)
+          url = Util::Config.get('endpoints.base_url') + Util::Config.get('endpoints.contacts')
+          url = build_url(url, param)
 
-					response = RestClient.get(url, get_headers(access_token))
-					body = JSON.parse(response.body)
+          response = RestClient.get(url, get_headers(access_token))
+          body = JSON.parse(response.body)
 
-					contacts = []
-					body['results'].each do |contact|
-						contacts << Components::Contact.create(contact)
-					end
+          contacts = []
+          body['results'].each do |contact|
+            contacts << Components::Contact.create(contact)
+          end
 
-					Components::ResultSet.new(contacts, body['meta'])
-				end
-
-
-				# Get contact details for a specific contact
-				# @param [String] access_token - Constant Contact OAuth2 access token
-				# @param [Integer] contact_id - Unique contact id
-				# @return [Contact]
-				def get_contact(access_token, contact_id)
-					url = Util::Config.get('endpoints.base_url') + 
-								sprintf(Util::Config.get('endpoints.contact'), contact_id)
-					url = build_url(url)
-					response = RestClient.get(url, get_headers(access_token))
-					Components::Contact.create(JSON.parse(response.body))
-				end
+          Components::ResultSet.new(contacts, body['meta'])
+        end
 
 
-				# Add a new contact to the Constant Contact account
-				# @param [String] access_token - Constant Contact OAuth2 access token
-				# @param [Contact] contact - Contact to add
-				# @param [Boolean] action_by_visitor - is the action being taken by the visitor
-				# @return [Contact]
-				def add_contact(access_token, contact, action_by_visitor = false)
-					url = Util::Config.get('endpoints.base_url') + Util::Config.get('endpoints.contacts')
-					param = action_by_visitor ? {'action_by' => 'ACTION_BY_VISITOR'} : nil
-					url = build_url(url, param)
-					payload = contact.to_json
-					response = RestClient.post(url, payload, get_headers(access_token))
-					Components::Contact.create(JSON.parse(response.body))
-				end
+        # Get contact details for a specific contact
+        # @param [String] access_token - Constant Contact OAuth2 access token
+        # @param [Integer] contact_id - Unique contact id
+        # @return [Contact]
+        def get_contact(access_token, contact_id)
+          url = Util::Config.get('endpoints.base_url') +
+                sprintf(Util::Config.get('endpoints.contact'), contact_id)
+          url = build_url(url)
+          response = RestClient.get(url, get_headers(access_token))
+          Components::Contact.create(JSON.parse(response.body))
+        end
 
 
-				# Delete contact details for a specific contact
-				# @param [String] access_token - Constant Contact OAuth2 access token
-				# @param [Integer] contact_id - Unique contact id
-				# @return [Boolean]
-				def delete_contact(access_token, contact_id)
-					url = Util::Config.get('endpoints.base_url') + sprintf(Util::Config.get('endpoints.contact'), contact_id)
-					url = build_url(url)
-					response = RestClient.delete(url, get_headers(access_token))
-					response.code == 204
-				end
+        # Add a new contact to the Constant Contact account
+        # @param [String] access_token - Constant Contact OAuth2 access token
+        # @param [Contact] contact - Contact to add
+        # @param [Boolean] action_by_visitor - is the action being taken by the visitor
+        # @return [Contact]
+        def add_contact(access_token, contact, action_by_visitor = false)
+          url = Util::Config.get('endpoints.base_url') + Util::Config.get('endpoints.contacts')
+          param = action_by_visitor ? {'action_by' => 'ACTION_BY_VISITOR'} : nil
+          url = build_url(url, param)
+          payload = contact.to_json
+          response = RestClient.post(url, payload, get_headers(access_token))
+          Components::Contact.create(JSON.parse(response.body))
+        end
 
 
-				# Delete a contact from all contact lists
-				# @param [String] access_token - Constant Contact OAuth2 access token
-				# @param [Integer] contact_id - Contact id to be removed from lists
-				# @return [Boolean]
-				def delete_contact_from_lists(access_token, contact_id)
-					url = Util::Config.get('endpoints.base_url') + sprintf(Util::Config.get('endpoints.contact_lists'), contact_id)
-					url = build_url(url)
-					response = RestClient.delete(url, get_headers(access_token))
-					response.code == 204
-				end
+        # Delete contact details for a specific contact
+        # @param [String] access_token - Constant Contact OAuth2 access token
+        # @param [Integer] contact_id - Unique contact id
+        # @return [Boolean]
+        def delete_contact(access_token, contact_id)
+          url = Util::Config.get('endpoints.base_url') + sprintf(Util::Config.get('endpoints.contact'), contact_id)
+          url = build_url(url)
+          response = RestClient.delete(url, get_headers(access_token))
+          response.code == 204
+        end
 
 
-				# Delete a contact from a specific contact list
-				# @param [String] access_token - Constant Contact OAuth2 access token
-				# @param [Integer] contact_id - Contact id to be removed
-				# @param [Integer] list_id - ContactList to remove the contact from
-				# @return [Boolean]
-				def delete_contact_from_list(access_token, contact_id, list_id)
-					url = Util::Config.get('endpoints.base_url') + sprintf(Util::Config.get('endpoints.contact_list'), contact_id, list_id)
-					url = build_url(url)
-					response = RestClient.delete(url, get_headers(access_token))
-					response.code == 204
-				end
+        # Delete a contact from all contact lists
+        # @param [String] access_token - Constant Contact OAuth2 access token
+        # @param [Integer] contact_id - Contact id to be removed from lists
+        # @return [Boolean]
+        def delete_contact_from_lists(access_token, contact_id)
+          url = Util::Config.get('endpoints.base_url') + sprintf(Util::Config.get('endpoints.contact_lists'), contact_id)
+          url = build_url(url)
+          response = RestClient.delete(url, get_headers(access_token))
+          response.code == 204
+        end
 
 
-				# Update contact details for a specific contact
-				# @param [String] access_token - Constant Contact OAuth2 access token
-				# @param [Contact] contact - Contact to be updated
-				# @param [Boolean] action_by_visitor - is the action being taken by the visitor
-				# @return [Contact]
-				def update_contact(access_token, contact, action_by_visitor = false)
-					url = Util::Config.get('endpoints.base_url') + sprintf(Util::Config.get('endpoints.contact'), contact.id)
-					param = action_by_visitor ? {'action_by' => 'ACTION_BY_VISITOR'} : nil
-					url = build_url(url, param)
-					payload = contact.to_json
-					response = RestClient.put(url, payload, get_headers(access_token))
-					Components::Contact.create(JSON.parse(response.body))
-				end
+        # Delete a contact from a specific contact list
+        # @param [String] access_token - Constant Contact OAuth2 access token
+        # @param [Integer] contact_id - Contact id to be removed
+        # @param [Integer] list_id - ContactList to remove the contact from
+        # @return [Boolean]
+        def delete_contact_from_list(access_token, contact_id, list_id)
+          url = Util::Config.get('endpoints.base_url') + sprintf(Util::Config.get('endpoints.contact_list'), contact_id, list_id)
+          url = build_url(url)
+          response = RestClient.delete(url, get_headers(access_token))
+          response.code == 204
+        end
 
-			end
-		end
-	end
+
+        # Update contact details for a specific contact
+        # @param [String] access_token - Constant Contact OAuth2 access token
+        # @param [Contact] contact - Contact to be updated
+        # @param [Boolean] action_by_visitor - is the action being taken by the visitor
+        # @return [Contact]
+        def update_contact(access_token, contact, action_by_visitor = false)
+          url = Util::Config.get('endpoints.base_url') + sprintf(Util::Config.get('endpoints.contact'), contact.id)
+          param = action_by_visitor ? {'action_by' => 'ACTION_BY_VISITOR'} : nil
+          url = build_url(url, param)
+          payload = contact.to_json
+          response = RestClient.put(url, payload, get_headers(access_token))
+          Components::Contact.create(JSON.parse(response.body))
+        end
+
+      end
+    end
+  end
 end

--- a/lib/constantcontact/services/contact_tracking_service.rb
+++ b/lib/constantcontact/services/contact_tracking_service.rb
@@ -5,155 +5,155 @@
 # Copyright (c) 2013 Constant Contact. All rights reserved.
 
 module ConstantContact
-	module Services
-		class ContactTrackingService < BaseService
-			class << self
+  module Services
+    class ContactTrackingService < BaseService
+      class << self
 
-				# Get a result set of bounces for a given contact
-				# @param [String] access_token - Constant Contact OAuth2 access token
-				# @param [String] contact_id - Contact id
-				# @param [Hash] param - query parameters to be appended to request
-				# @return [ResultSet<BounceActivity>] - Containing a results array of BounceActivity
-				def get_bounces(access_token, contact_id, param = nil)
-					url = Util::Config.get('endpoints.base_url') +
-								sprintf(Util::Config.get('endpoints.contact_tracking_bounces'), contact_id)
-					url = build_url(url, param)
+        # Get a result set of bounces for a given contact
+        # @param [String] access_token - Constant Contact OAuth2 access token
+        # @param [String] contact_id - Contact id
+        # @param [Hash] param - query parameters to be appended to request
+        # @return [ResultSet<BounceActivity>] - Containing a results array of BounceActivity
+        def get_bounces(access_token, contact_id, param = nil)
+          url = Util::Config.get('endpoints.base_url') +
+                sprintf(Util::Config.get('endpoints.contact_tracking_bounces'), contact_id)
+          url = build_url(url, param)
 
-					response = RestClient.get(url, get_headers(access_token))
-					body = JSON.parse(response.body)
+          response = RestClient.get(url, get_headers(access_token))
+          body = JSON.parse(response.body)
 
-					bounces = []
-					body['results'].each do |bounce_activity|
-						bounces << Components::BounceActivity.create(bounce_activity)
-					end
+          bounces = []
+          body['results'].each do |bounce_activity|
+            bounces << Components::BounceActivity.create(bounce_activity)
+          end
 
-					Components::ResultSet.new(bounces, body['meta'])
-				end
-
-
-				# Get clicks for a given contact
-				# @param [String] access_token - Constant Contact OAuth2 access token
-				# @param [String] contact_id - Contact id
-				# @param [Hash] param - query parameters to be appended to request
-				# @return [ResultSet<ClickActivity>] - Containing a results array of ClickActivity
-				def get_clicks(access_token, contact_id, param = nil)
-					url = Util::Config.get('endpoints.base_url') +
-								sprintf(Util::Config.get('endpoints.contact_tracking_clicks'), contact_id)
-					url = build_url(url, param)
-
-					response = RestClient.get(url, get_headers(access_token))
-					body = JSON.parse(response.body)
-
-					clicks = []
-					body['results'].each do |click_activity|
-						clicks << Components::ClickActivity.create(click_activity)
-					end
-
-					Components::ResultSet.new(clicks, body['meta'])
-				end
+          Components::ResultSet.new(bounces, body['meta'])
+        end
 
 
-				# Get forwards for a given contact
-				# @param [String] access_token - Constant Contact OAuth2 access token
-				# @param [String] contact_id - Contact id
-				# @param [Hash] param - query parameters to be appended to request
-				# @return [ResultSet<ForwardActivity>] - Containing a results array of ForwardActivity
-				def get_forwards(access_token, contact_id, param = nil)
-					url = Util::Config.get('endpoints.base_url') +
-								sprintf(Util::Config.get('endpoints.contact_tracking_forwards'), contact_id)
-					url = build_url(url, param)
+        # Get clicks for a given contact
+        # @param [String] access_token - Constant Contact OAuth2 access token
+        # @param [String] contact_id - Contact id
+        # @param [Hash] param - query parameters to be appended to request
+        # @return [ResultSet<ClickActivity>] - Containing a results array of ClickActivity
+        def get_clicks(access_token, contact_id, param = nil)
+          url = Util::Config.get('endpoints.base_url') +
+                sprintf(Util::Config.get('endpoints.contact_tracking_clicks'), contact_id)
+          url = build_url(url, param)
 
-					response = RestClient.get(url, get_headers(access_token))
-					body = JSON.parse(response.body)
+          response = RestClient.get(url, get_headers(access_token))
+          body = JSON.parse(response.body)
 
-					forwards = []
-					body['results'].each do |forward_activity|
-						forwards << Components::ForwardActivity.create(forward_activity)
-					end
+          clicks = []
+          body['results'].each do |click_activity|
+            clicks << Components::ClickActivity.create(click_activity)
+          end
 
-					Components::ResultSet.new(forwards, body['meta'])
-				end
-
-
-				# Get opens for a given contact
-				# @param [String] access_token - Constant Contact OAuth2 access token
-				# @param [String] contact_id - Contact id
-				# @param [Hash] param - query parameters to be appended to request
-				# @return [ResultSet<OpenActivity>] - Containing a results array of OpenActivity
-				def get_opens(access_token, contact_id, param = nil)
-					url = Util::Config.get('endpoints.base_url') +
-								sprintf(Util::Config.get('endpoints.contact_tracking_opens'), contact_id)
-					url = build_url(url, param)
-
-					response = RestClient.get(url, get_headers(access_token))
-					body = JSON.parse(response.body)
-
-					opens = []
-					body['results'].each do |open_activity|
-						opens << Components::OpenActivity.create(open_activity)
-					end
-
-					Components::ResultSet.new(opens, body['meta'])
-				end
+          Components::ResultSet.new(clicks, body['meta'])
+        end
 
 
-				# Get sends for a given contact
-				# @param [String] access_token - Constant Contact OAuth2 access token
-				# @param [String] contact_id - Contact id
-				# @param [Hash] param - query parameters to be appended to request
-				# @return [ResultSet<SendActivity>] - Containing a results array of SendActivity
-				def get_sends(access_token, contact_id, param = nil)
-					url = Util::Config.get('endpoints.base_url') +
-								sprintf(Util::Config.get('endpoints.contact_tracking_sends'), contact_id)
-					url = build_url(url, param)
+        # Get forwards for a given contact
+        # @param [String] access_token - Constant Contact OAuth2 access token
+        # @param [String] contact_id - Contact id
+        # @param [Hash] param - query parameters to be appended to request
+        # @return [ResultSet<ForwardActivity>] - Containing a results array of ForwardActivity
+        def get_forwards(access_token, contact_id, param = nil)
+          url = Util::Config.get('endpoints.base_url') +
+                sprintf(Util::Config.get('endpoints.contact_tracking_forwards'), contact_id)
+          url = build_url(url, param)
 
-					response = RestClient.get(url, get_headers(access_token))
-					body = JSON.parse(response.body)
+          response = RestClient.get(url, get_headers(access_token))
+          body = JSON.parse(response.body)
 
-					sends = []
-					body['results'].each do |send_activity|
-						sends << Components::SendActivity.create(send_activity)
-					end
+          forwards = []
+          body['results'].each do |forward_activity|
+            forwards << Components::ForwardActivity.create(forward_activity)
+          end
 
-					Components::ResultSet.new(sends, body['meta'])
-				end
-
-
-				# Get unsubscribes for a given contact
-				# @param [String] access_token - Constant Contact OAuth2 access token
-				# @param [String] contact_id - Contact id
-				# @param [Hash] param - query parameters to be appended to request
-				# @return [ResultSet<UnsubscribeActivity>] - Containing a results array of UnsubscribeActivity
-				def get_unsubscribes(access_token, contact_id, param = nil)
-					url = Util::Config.get('endpoints.base_url') +
-								sprintf(Util::Config.get('endpoints.contact_tracking_unsubscribes'), contact_id)
-					url = build_url(url, param)
-
-					response = RestClient.get(url, get_headers(access_token))
-					body = JSON.parse(response.body)
-
-					unsubscribes = []
-					body['results'].each do |unsubscribe_activity|
-						unsubscribes[] = Components::UnsubscribeActivity.create(unsubscribe_activity)
-					end
-
-					Components::ResultSet.new(unsubscribes, body['meta'])
-				end
+          Components::ResultSet.new(forwards, body['meta'])
+        end
 
 
-				# Get a summary of reporting data for a given contact
-				# @param [String] access_token - Constant Contact OAuth2 access token
-				# @param [String] contact_id - Contact id
-				# @return [TrackingSummary]
-				def get_summary(access_token, contact_id)
-					url = Util::Config.get('endpoints.base_url') +
-								sprintf(Util::Config.get('endpoints.contact_tracking_summary'), contact_id)
-					url = build_url(url)
-					response = RestClient.get(url, get_headers(access_token))
-					Components::TrackingSummary.create(JSON.parse(response.body))
-				end
+        # Get opens for a given contact
+        # @param [String] access_token - Constant Contact OAuth2 access token
+        # @param [String] contact_id - Contact id
+        # @param [Hash] param - query parameters to be appended to request
+        # @return [ResultSet<OpenActivity>] - Containing a results array of OpenActivity
+        def get_opens(access_token, contact_id, param = nil)
+          url = Util::Config.get('endpoints.base_url') +
+                sprintf(Util::Config.get('endpoints.contact_tracking_opens'), contact_id)
+          url = build_url(url, param)
 
-			end
-		end
-	end
+          response = RestClient.get(url, get_headers(access_token))
+          body = JSON.parse(response.body)
+
+          opens = []
+          body['results'].each do |open_activity|
+            opens << Components::OpenActivity.create(open_activity)
+          end
+
+          Components::ResultSet.new(opens, body['meta'])
+        end
+
+
+        # Get sends for a given contact
+        # @param [String] access_token - Constant Contact OAuth2 access token
+        # @param [String] contact_id - Contact id
+        # @param [Hash] param - query parameters to be appended to request
+        # @return [ResultSet<SendActivity>] - Containing a results array of SendActivity
+        def get_sends(access_token, contact_id, param = nil)
+          url = Util::Config.get('endpoints.base_url') +
+                sprintf(Util::Config.get('endpoints.contact_tracking_sends'), contact_id)
+          url = build_url(url, param)
+
+          response = RestClient.get(url, get_headers(access_token))
+          body = JSON.parse(response.body)
+
+          sends = []
+          body['results'].each do |send_activity|
+            sends << Components::SendActivity.create(send_activity)
+          end
+
+          Components::ResultSet.new(sends, body['meta'])
+        end
+
+
+        # Get unsubscribes for a given contact
+        # @param [String] access_token - Constant Contact OAuth2 access token
+        # @param [String] contact_id - Contact id
+        # @param [Hash] param - query parameters to be appended to request
+        # @return [ResultSet<UnsubscribeActivity>] - Containing a results array of UnsubscribeActivity
+        def get_unsubscribes(access_token, contact_id, param = nil)
+          url = Util::Config.get('endpoints.base_url') +
+                sprintf(Util::Config.get('endpoints.contact_tracking_unsubscribes'), contact_id)
+          url = build_url(url, param)
+
+          response = RestClient.get(url, get_headers(access_token))
+          body = JSON.parse(response.body)
+
+          unsubscribes = []
+          body['results'].each do |unsubscribe_activity|
+            unsubscribes[] = Components::UnsubscribeActivity.create(unsubscribe_activity)
+          end
+
+          Components::ResultSet.new(unsubscribes, body['meta'])
+        end
+
+
+        # Get a summary of reporting data for a given contact
+        # @param [String] access_token - Constant Contact OAuth2 access token
+        # @param [String] contact_id - Contact id
+        # @return [TrackingSummary]
+        def get_summary(access_token, contact_id)
+          url = Util::Config.get('endpoints.base_url') +
+                sprintf(Util::Config.get('endpoints.contact_tracking_summary'), contact_id)
+          url = build_url(url)
+          response = RestClient.get(url, get_headers(access_token))
+          Components::TrackingSummary.create(JSON.parse(response.body))
+        end
+
+      end
+    end
+  end
 end

--- a/lib/constantcontact/services/email_marketing_service.rb
+++ b/lib/constantcontact/services/email_marketing_service.rb
@@ -5,83 +5,83 @@
 # Copyright (c) 2013 Constant Contact. All rights reserved.
 
 module ConstantContact
-	module Services
-		class EmailMarketingService < BaseService
-			class << self
+  module Services
+    class EmailMarketingService < BaseService
+      class << self
 
-				# Create a new campaign
-				# @param [String] access_token - Constant Contact OAuth2 access token
-				# @param [Campaign] campaign - Campaign to be created
-				# @return [Campaign]
-				def add_campaign(access_token, campaign)
-					url = Util::Config.get('endpoints.base_url') + Util::Config.get('endpoints.campaigns')
-					url = build_url(url)
-					payload = campaign.to_json
-					response = RestClient.post(url, payload, get_headers(access_token))
-					Components::Campaign.create(JSON.parse(response.body))
-				end
-
-
-				# Get a set of campaigns
-				# @param [String] access_token - Constant Contact OAuth2 access token
-				# @param [Hash] param - query parameters to be appended to the request
-				# @return [ResultSet<Campaign>]
-				def get_campaigns(access_token, param = nil)
-					url = Util::Config.get('endpoints.base_url') + Util::Config.get('endpoints.campaigns')
-					url = build_url(url, param)
-
-					response = RestClient.get(url, get_headers(access_token))
-					body = JSON.parse(response.body)
-
-					campaigns = []
-					body['results'].each do |campaign|
-						campaigns << Components::Campaign.create_summary(campaign)
-					end
-
-					Components::ResultSet.new(campaigns, body['meta'])
-				end
+        # Create a new campaign
+        # @param [String] access_token - Constant Contact OAuth2 access token
+        # @param [Campaign] campaign - Campaign to be created
+        # @return [Campaign]
+        def add_campaign(access_token, campaign)
+          url = Util::Config.get('endpoints.base_url') + Util::Config.get('endpoints.campaigns')
+          url = build_url(url)
+          payload = campaign.to_json
+          response = RestClient.post(url, payload, get_headers(access_token))
+          Components::Campaign.create(JSON.parse(response.body))
+        end
 
 
-				# Get campaign details for a specific campaign
-				# @param [String] access_token - Constant Contact OAuth2 access token
-				# @param [Integer] campaign_id - Valid campaign id
-				# @return [Campaign]
-				def get_campaign(access_token, campaign_id)
-					url = Util::Config.get('endpoints.base_url') + 
-								sprintf(Util::Config.get('endpoints.campaign'), campaign_id)
-					url = build_url(url)
-					response = RestClient.get(url, get_headers(access_token))
-					Components::Campaign.create(JSON.parse(response.body))
-				end
+        # Get a set of campaigns
+        # @param [String] access_token - Constant Contact OAuth2 access token
+        # @param [Hash] param - query parameters to be appended to the request
+        # @return [ResultSet<Campaign>]
+        def get_campaigns(access_token, param = nil)
+          url = Util::Config.get('endpoints.base_url') + Util::Config.get('endpoints.campaigns')
+          url = build_url(url, param)
+
+          response = RestClient.get(url, get_headers(access_token))
+          body = JSON.parse(response.body)
+
+          campaigns = []
+          body['results'].each do |campaign|
+            campaigns << Components::Campaign.create_summary(campaign)
+          end
+
+          Components::ResultSet.new(campaigns, body['meta'])
+        end
 
 
-				# Delete an email campaign
-				# @param [String] access_token - Constant Contact OAuth2 access token
-				# @param [Integer] campaign_id - Valid campaign id
-				# @return [Boolean]
-				def delete_campaign(access_token, campaign_id)
-					url = Util::Config.get('endpoints.base_url') + 
-								sprintf(Util::Config.get('endpoints.campaign'), campaign_id)
-					url = build_url(url)
-					response = RestClient.delete(url, get_headers(access_token))
-					response.code == 204
-				end
+        # Get campaign details for a specific campaign
+        # @param [String] access_token - Constant Contact OAuth2 access token
+        # @param [Integer] campaign_id - Valid campaign id
+        # @return [Campaign]
+        def get_campaign(access_token, campaign_id)
+          url = Util::Config.get('endpoints.base_url') +
+                sprintf(Util::Config.get('endpoints.campaign'), campaign_id)
+          url = build_url(url)
+          response = RestClient.get(url, get_headers(access_token))
+          Components::Campaign.create(JSON.parse(response.body))
+        end
 
 
-				# Update a specific email campaign
-				# @param [String] access_token - Constant Contact OAuth2 access token
-				# @param [Campaign] campaign - Campaign to be updated
-				# @return [Campaign]
-				def update_campaign(access_token, campaign)
-					url = Util::Config.get('endpoints.base_url') + 
-								sprintf(Util::Config.get('endpoints.campaign'), campaign.id)
-					url = build_url(url)
-					payload = campaign.to_json
-					response = RestClient.put(url, payload, get_headers(access_token))
-					Components::Campaign.create(JSON.parse(response.body))
-				end
+        # Delete an email campaign
+        # @param [String] access_token - Constant Contact OAuth2 access token
+        # @param [Integer] campaign_id - Valid campaign id
+        # @return [Boolean]
+        def delete_campaign(access_token, campaign_id)
+          url = Util::Config.get('endpoints.base_url') +
+                sprintf(Util::Config.get('endpoints.campaign'), campaign_id)
+          url = build_url(url)
+          response = RestClient.delete(url, get_headers(access_token))
+          response.code == 204
+        end
 
-			end
-		end
-	end
+
+        # Update a specific email campaign
+        # @param [String] access_token - Constant Contact OAuth2 access token
+        # @param [Campaign] campaign - Campaign to be updated
+        # @return [Campaign]
+        def update_campaign(access_token, campaign)
+          url = Util::Config.get('endpoints.base_url') +
+                sprintf(Util::Config.get('endpoints.campaign'), campaign.id)
+          url = build_url(url)
+          payload = campaign.to_json
+          response = RestClient.put(url, payload, get_headers(access_token))
+          Components::Campaign.create(JSON.parse(response.body))
+        end
+
+      end
+    end
+  end
 end

--- a/lib/constantcontact/services/list_service.rb
+++ b/lib/constantcontact/services/list_service.rb
@@ -5,81 +5,81 @@
 # Copyright (c) 2013 Constant Contact. All rights reserved.
 
 module ConstantContact
-	module Services
-		class ListService < BaseService
-			class << self
+  module Services
+    class ListService < BaseService
+      class << self
 
-				# Get lists within an account
-				# @param [String] access_token - Constant Contact OAuth2 access token
-				# @return [Array<ContactList>]
-				def get_lists(access_token)
-					url = Util::Config.get('endpoints.base_url') + Util::Config.get('endpoints.lists')
-					url = build_url(url)
-					response = RestClient.get(url, get_headers(access_token))
-					lists = []
-					JSON.parse(response.body).each do |contact|
-						lists << Components::ContactList.create(contact)
-					end
-					lists
-				end
-
-
-				# Add a new list to the Constant Contact account
-				# @param [String] access_token - Constant Contact OAuth2 access token
-				# @param [ContactList] list
-				# @return [ContactList]
-				def add_list(access_token, list)
-					url = Util::Config.get('endpoints.base_url') + Util::Config.get('endpoints.lists')
-					url = build_url(url)
-					payload = list.to_json
-					response = RestClient.post(url, payload, get_headers(access_token))
-					Components::ContactList.create(JSON.parse(response.body))
-				end
+        # Get lists within an account
+        # @param [String] access_token - Constant Contact OAuth2 access token
+        # @return [Array<ContactList>]
+        def get_lists(access_token)
+          url = Util::Config.get('endpoints.base_url') + Util::Config.get('endpoints.lists')
+          url = build_url(url)
+          response = RestClient.get(url, get_headers(access_token))
+          lists = []
+          JSON.parse(response.body).each do |contact|
+            lists << Components::ContactList.create(contact)
+          end
+          lists
+        end
 
 
-				# Update a Contact List
-				# @param [String] access_token - Constant Contact OAuth2 access token
-				# @param [ContactList] list - ContactList to be updated
-				# @return [ContactList]
-				def update_list(access_token, list)
-					url = Util::Config.get('endpoints.base_url') + sprintf(Util::Config.get('endpoints.list'), list.id)
-					url = build_url(url)
-					payload = list.to_json
-					response = RestClient.put(url, payload, get_headers(access_token))
-					Components::ContactList.create(JSON.parse(response.body))
-				end
+        # Add a new list to the Constant Contact account
+        # @param [String] access_token - Constant Contact OAuth2 access token
+        # @param [ContactList] list
+        # @return [ContactList]
+        def add_list(access_token, list)
+          url = Util::Config.get('endpoints.base_url') + Util::Config.get('endpoints.lists')
+          url = build_url(url)
+          payload = list.to_json
+          response = RestClient.post(url, payload, get_headers(access_token))
+          Components::ContactList.create(JSON.parse(response.body))
+        end
 
 
-				# Get an individual contact list
-				# @param [String] access_token - Constant Contact OAuth2 access token
-				# @param [Integer] list_id - list id
-				# @return [ContactList]
-				def get_list(access_token, list_id)
-					url = Util::Config.get('endpoints.base_url') + sprintf(Util::Config.get('endpoints.list'), list_id)
-					url = build_url(url)
-					response = RestClient.get(url, get_headers(access_token))
-					Components::ContactList.create(JSON.parse(response.body))
-				end
+        # Update a Contact List
+        # @param [String] access_token - Constant Contact OAuth2 access token
+        # @param [ContactList] list - ContactList to be updated
+        # @return [ContactList]
+        def update_list(access_token, list)
+          url = Util::Config.get('endpoints.base_url') + sprintf(Util::Config.get('endpoints.list'), list.id)
+          url = build_url(url)
+          payload = list.to_json
+          response = RestClient.put(url, payload, get_headers(access_token))
+          Components::ContactList.create(JSON.parse(response.body))
+        end
 
 
-				# Get all contacts from an individual list
-				# @param [String] access_token - Constant Contact OAuth2 access token
-				# @param [Integer] list_id - list id to retrieve contacts for
-				# @param [Hash] param - query parameters to attach to request
-				# @return [Array<Contact>]
-				def get_contacts_from_list(access_token, list_id, param = nil)
-					url = Util::Config.get('endpoints.base_url') + sprintf(Util::Config.get('endpoints.list_contacts'), list_id)
-					url = build_url(url, param)
-					response = RestClient.get(url, get_headers(access_token))
-					contacts = []
-					body = JSON.parse(response.body)
-					body['results'].each do |contact|
-						contacts << Components::Contact.create(contact)
-					end
-					Components::ResultSet.new(contacts, body['meta'])
-				end
+        # Get an individual contact list
+        # @param [String] access_token - Constant Contact OAuth2 access token
+        # @param [Integer] list_id - list id
+        # @return [ContactList]
+        def get_list(access_token, list_id)
+          url = Util::Config.get('endpoints.base_url') + sprintf(Util::Config.get('endpoints.list'), list_id)
+          url = build_url(url)
+          response = RestClient.get(url, get_headers(access_token))
+          Components::ContactList.create(JSON.parse(response.body))
+        end
 
-			end
-		end
-	end
+
+        # Get all contacts from an individual list
+        # @param [String] access_token - Constant Contact OAuth2 access token
+        # @param [Integer] list_id - list id to retrieve contacts for
+        # @param [Hash] param - query parameters to attach to request
+        # @return [Array<Contact>]
+        def get_contacts_from_list(access_token, list_id, param = nil)
+          url = Util::Config.get('endpoints.base_url') + sprintf(Util::Config.get('endpoints.list_contacts'), list_id)
+          url = build_url(url, param)
+          response = RestClient.get(url, get_headers(access_token))
+          contacts = []
+          body = JSON.parse(response.body)
+          body['results'].each do |contact|
+            contacts << Components::Contact.create(contact)
+          end
+          Components::ResultSet.new(contacts, body['meta'])
+        end
+
+      end
+    end
+  end
 end

--- a/lib/constantcontact/util/config.rb
+++ b/lib/constantcontact/util/config.rb
@@ -5,136 +5,136 @@
 # Copyright (c) 2013 Constant Contact. All rights reserved.
 
 module ConstantContact
-	module Util
-		class Config
+  module Util
+    class Config
 
-			class << self
+      class << self
 
-				# Return a hash of configuration strings
-				# @return [Hash] - hash of configuration properties
-				def props
-					{
-						# REST endpoints
-						:endpoints => {
-							:base_url                       => 'https://api.constantcontact.com/v2/',
+        # Return a hash of configuration strings
+        # @return [Hash] - hash of configuration properties
+        def props
+          {
+            # REST endpoints
+            :endpoints => {
+              :base_url                       => 'https://api.constantcontact.com/v2/',
 
-							:activity                       => 'activities/%s',
-							:activities                     => 'activities',
-							:export_contacts_activity       => 'activities/exportcontacts',
-							:clear_lists_activity           => 'activities/clearlists',
-							:remove_from_lists_activity     => 'activities/removefromlists',
-							:add_contacts_activity          => 'activities/addcontacts',
+              :activity                       => 'activities/%s',
+              :activities                     => 'activities',
+              :export_contacts_activity       => 'activities/exportcontacts',
+              :clear_lists_activity           => 'activities/clearlists',
+              :remove_from_lists_activity     => 'activities/removefromlists',
+              :add_contacts_activity          => 'activities/addcontacts',
 
-							:account_verified_addresses     => 'account/verifiedemailaddresses',
+              :account_verified_addresses     => 'account/verifiedemailaddresses',
 
-							:contact                        => 'contacts/%s',
-							:contacts                       => 'contacts',
-							:lists                          => 'lists',
-							:list                           => 'lists/%s',
-							:list_contacts                  => 'lists/%s/contacts',
-							:contact_lists                  => 'contacts/%s/lists',
-							:contact_list                   => 'contacts/%s/lists/%s',
+              :contact                        => 'contacts/%s',
+              :contacts                       => 'contacts',
+              :lists                          => 'lists',
+              :list                           => 'lists/%s',
+              :list_contacts                  => 'lists/%s/contacts',
+              :contact_lists                  => 'contacts/%s/lists',
+              :contact_list                   => 'contacts/%s/lists/%s',
 
-							:campaigns                      => 'emailmarketing/campaigns',
-							:campaign                       => 'emailmarketing/campaigns/%s',
-							:campaign_schedules             => 'emailmarketing/campaigns/%s/schedules',
-							:campaign_schedule              => 'emailmarketing/campaigns/%s/schedules/%s',
-							:campaign_test_sends            => 'emailmarketing/campaigns/%s/tests',
-							:campaign_tracking_summary      => 'emailmarketing/campaigns/%s/tracking/reports/summary',
-							:campaign_tracking_bounces      => 'emailmarketing/campaigns/%s/tracking/bounces',
-							:campaign_tracking_clicks       => 'emailmarketing/campaigns/%s/tracking/clicks',
-							:campaign_tracking_forwards     => 'emailmarketing/campaigns/%s/tracking/forwards',
-							:campaign_tracking_opens        => 'emailmarketing/campaigns/%s/tracking/opens',
-							:campaign_tracking_sends        => 'emailmarketing/campaigns/%s/tracking/sends',
-							:campaign_tracking_unsubscribes => 'emailmarketing/campaigns/%s/tracking/unsubscribes',
-							:campaign_tracking_link         => 'emailmarketing/campaigns/%s/tracking/clicks/%s',
+              :campaigns                      => 'emailmarketing/campaigns',
+              :campaign                       => 'emailmarketing/campaigns/%s',
+              :campaign_schedules             => 'emailmarketing/campaigns/%s/schedules',
+              :campaign_schedule              => 'emailmarketing/campaigns/%s/schedules/%s',
+              :campaign_test_sends            => 'emailmarketing/campaigns/%s/tests',
+              :campaign_tracking_summary      => 'emailmarketing/campaigns/%s/tracking/reports/summary',
+              :campaign_tracking_bounces      => 'emailmarketing/campaigns/%s/tracking/bounces',
+              :campaign_tracking_clicks       => 'emailmarketing/campaigns/%s/tracking/clicks',
+              :campaign_tracking_forwards     => 'emailmarketing/campaigns/%s/tracking/forwards',
+              :campaign_tracking_opens        => 'emailmarketing/campaigns/%s/tracking/opens',
+              :campaign_tracking_sends        => 'emailmarketing/campaigns/%s/tracking/sends',
+              :campaign_tracking_unsubscribes => 'emailmarketing/campaigns/%s/tracking/unsubscribes',
+              :campaign_tracking_link         => 'emailmarketing/campaigns/%s/tracking/clicks/%s',
 
-							:contact_tracking_summary       => 'contacts/%s/tracking/reports/summary',
-							:contact_tracking_bounces       => 'contacts/%s/tracking/bounces',
-							:contact_tracking_clicks        => 'contacts/%s/tracking/clicks',
-							:contact_tracking_forwards      => 'contacts/%s/tracking/forwards',
-							:contact_tracking_opens         => 'contacts/%s/tracking/opens',
-							:contact_tracking_sends         => 'contacts/%s/tracking/sends',
-							:contact_tracking_unsubscribes  => 'contacts/%s/tracking/unsubscribes',
-							:contact_tracking_link          => 'contacts/%s/tracking/clicks/%s'
-						},
+              :contact_tracking_summary       => 'contacts/%s/tracking/reports/summary',
+              :contact_tracking_bounces       => 'contacts/%s/tracking/bounces',
+              :contact_tracking_clicks        => 'contacts/%s/tracking/clicks',
+              :contact_tracking_forwards      => 'contacts/%s/tracking/forwards',
+              :contact_tracking_opens         => 'contacts/%s/tracking/opens',
+              :contact_tracking_sends         => 'contacts/%s/tracking/sends',
+              :contact_tracking_unsubscribes  => 'contacts/%s/tracking/unsubscribes',
+              :contact_tracking_link          => 'contacts/%s/tracking/clicks/%s'
+            },
 
-						# OAuth2 Authorization related configuration options
-						:auth => {
-							:base_url                      => 'https://oauth2.constantcontact.com/oauth2/',
-							:response_type_code            => 'code',
-							:response_type_token           => 'token',
-							:authorization_code_grant_type => 'authorization_code',
-							:authorization_endpoint        => 'oauth/siteowner/authorize',
-							:token_endpoint                => 'oauth/token'
-						},
+            # OAuth2 Authorization related configuration options
+            :auth => {
+              :base_url                      => 'https://oauth2.constantcontact.com/oauth2/',
+              :response_type_code            => 'code',
+              :response_type_token           => 'token',
+              :authorization_code_grant_type => 'authorization_code',
+              :authorization_endpoint        => 'oauth/siteowner/authorize',
+              :token_endpoint                => 'oauth/token'
+            },
 
-						# Column names used with bulk activities
-						:activities_columns => {
-							:email            => 'EMAIL',
-							:first_name       => 'FIRST NAME',
-							:middle_name      => 'MIDDLE NAME',
-							:last_name        => 'LAST NAME',
-							:job_title        => 'JOB TITLE',
-							:company_name     => 'COMPANY NAME',
-							:work_phone       => 'WORK PHONE',
-							:home_phone       => 'HOME PHONE',
-							:address1         => 'ADDRESS LINE 1',
-							:address2         => 'ADDRESS LINE 2',
-							:address3         => 'ADDRESS LINE 3',
-							:city             => 'CITY',
-							:state            => 'STATE',
-							:state_province   => 'US STATE/CA PROVINCE',
-							:country          => 'COUNTRY',
-							:postal_code      => 'ZIP/POSTAL CODE',
-							:sub_postal_code  => 'SUB ZIP/POSTAL CODE',
-							:custom_field_1   => 'CUSTOM FIELD 1',
-							:custom_field_2   => 'CUSTOM FIELD 2',
-							:custom_field_3   => 'CUSTOM FIELD 3',
-							:custom_field_4   => 'CUSTOM FIELD 4',
-							:custom_field_5   => 'CUSTOM FIELD 5',
-							:custom_field_6   => 'CUSTOM FIELD 6',
-							:custom_field_7   => 'CUSTOM FIELD 7',
-							:custom_field_8   => 'CUSTOM FIELD 8',
-							:custom_field_9   => 'CUSTOM FIELD 9',
-							:custom_field_10  => 'CUSTOM FIELD 10',
-							:custom_field_11  => 'CUSTOM FIELD 11',
-							:custom_field_12  => 'CUSTOM FIELD 12',
-							:custom_field_13  => 'CUSTOM FIELD 13',
-							:custom_field_14  => 'CUSTOM FIELD 14',
-							:custom_field_15  => 'CUSTOM FIELD 15'
-						},
+            # Column names used with bulk activities
+            :activities_columns => {
+              :email            => 'EMAIL',
+              :first_name       => 'FIRST NAME',
+              :middle_name      => 'MIDDLE NAME',
+              :last_name        => 'LAST NAME',
+              :job_title        => 'JOB TITLE',
+              :company_name     => 'COMPANY NAME',
+              :work_phone       => 'WORK PHONE',
+              :home_phone       => 'HOME PHONE',
+              :address1         => 'ADDRESS LINE 1',
+              :address2         => 'ADDRESS LINE 2',
+              :address3         => 'ADDRESS LINE 3',
+              :city             => 'CITY',
+              :state            => 'STATE',
+              :state_province   => 'US STATE/CA PROVINCE',
+              :country          => 'COUNTRY',
+              :postal_code      => 'ZIP/POSTAL CODE',
+              :sub_postal_code  => 'SUB ZIP/POSTAL CODE',
+              :custom_field_1   => 'CUSTOM FIELD 1',
+              :custom_field_2   => 'CUSTOM FIELD 2',
+              :custom_field_3   => 'CUSTOM FIELD 3',
+              :custom_field_4   => 'CUSTOM FIELD 4',
+              :custom_field_5   => 'CUSTOM FIELD 5',
+              :custom_field_6   => 'CUSTOM FIELD 6',
+              :custom_field_7   => 'CUSTOM FIELD 7',
+              :custom_field_8   => 'CUSTOM FIELD 8',
+              :custom_field_9   => 'CUSTOM FIELD 9',
+              :custom_field_10  => 'CUSTOM FIELD 10',
+              :custom_field_11  => 'CUSTOM FIELD 11',
+              :custom_field_12  => 'CUSTOM FIELD 12',
+              :custom_field_13  => 'CUSTOM FIELD 13',
+              :custom_field_14  => 'CUSTOM FIELD 14',
+              :custom_field_15  => 'CUSTOM FIELD 15'
+            },
 
-						# Errors to be returned for various exceptions
-						:errors => {
-							:id_or_object => 'Only an id or %s object are allowed for this method.'
-						}
-					}
-				end
+            # Errors to be returned for various exceptions
+            :errors => {
+              :id_or_object => 'Only an id or %s object are allowed for this method.'
+            }
+          }
+        end
 
-				# Get a configuration property given a specified location, example usage: Config::get('auth.token_endpoint')
-				# @param [String] index - location of the property to obtain
-				# @return [String]
-				def get(index)
-					properties = index.split('.')
-					get_value(properties, props)
-				end
+        # Get a configuration property given a specified location, example usage: Config::get('auth.token_endpoint')
+        # @param [String] index - location of the property to obtain
+        # @return [String]
+        def get(index)
+          properties = index.split('.')
+          get_value(properties, props)
+        end
 
-				private
+        private
 
-				# Navigate through a config array looking for a particular index
-				# @param [Array] index The index sequence we are navigating down
-				# @param [Hash, String] value The portion of the config array to process
-				# @return [String]
-				def get_value(index, value)
-					index = index.is_a?(Array) ? index : [index]
-					key = index.shift.to_sym
-					value.is_a?(Hash) and value[key] and value[key].is_a?(Hash) ?
-					get_value(index, value[key]) :
-					value[key]
-				end
-			end
+        # Navigate through a config array looking for a particular index
+        # @param [Array] index The index sequence we are navigating down
+        # @param [Hash, String] value The portion of the config array to process
+        # @return [String]
+        def get_value(index, value)
+          index = index.is_a?(Array) ? index : [index]
+          key = index.shift.to_sym
+          value.is_a?(Hash) and value[key] and value[key].is_a?(Hash) ?
+          get_value(index, value[key]) :
+          value[key]
+        end
+      end
 
-		end
-	end
+    end
+  end
 end

--- a/lib/constantcontact/util/helpers.rb
+++ b/lib/constantcontact/util/helpers.rb
@@ -5,23 +5,23 @@
 # Copyright (c) 2013 Constant Contact. All rights reserved.
 
 module ConstantContact
-	module Util
-		class Helpers
-			class << self
-			
-				# Build the HTTP query from the given parameters
-				# @param [Hash] params
-				# @return [String] query string
-				def http_build_query(params)
-					params.collect{ |k,v| "#{k.to_s}=#{encode(v.to_s)}" }.reverse.join('&')
-				end
+  module Util
+    class Helpers
+      class << self
 
-				# Escape special characters
-				# @param [String] str
-				def encode(str)
-					CGI.escape(str).gsub('.', '%2E').gsub('-', '%2D')
-				end
-			end
-		end
-	end
+        # Build the HTTP query from the given parameters
+        # @param [Hash] params
+        # @return [String] query string
+        def http_build_query(params)
+          params.collect{ |k,v| "#{k.to_s}=#{encode(v.to_s)}" }.reverse.join('&')
+        end
+
+        # Escape special characters
+        # @param [String] str
+        def encode(str)
+          CGI.escape(str).gsub('.', '%2E').gsub('-', '%2D')
+        end
+      end
+    end
+  end
 end

--- a/lib/constantcontact/version.rb
+++ b/lib/constantcontact/version.rb
@@ -5,8 +5,8 @@
 # Copyright (c) 2013 Constant Contact. All rights reserved.
 
 module ConstantContact
-	module SDK
-		# Gem version
-		VERSION = "1.0.0"
-	end
+  module SDK
+    # Gem version
+    VERSION = "1.0.0"
+  end
 end

--- a/spec/constantcontact/api_spec.rb
+++ b/spec/constantcontact/api_spec.rb
@@ -7,177 +7,177 @@
 require 'spec_helper'
 
 describe ConstantContact::Api do
-	before(:each) do
-		@api = ConstantContact::Api.new('api key')
-	end
+  before(:each) do
+    @api = ConstantContact::Api.new('api key')
+  end
 
-	describe "#get_contacts" do
-		it "returns an array of contacts" do
-			json = load_json('contacts.json')
-			net_http_resp = Net::HTTPResponse.new(1.0, 200, 'OK')
+  describe "#get_contacts" do
+    it "returns an array of contacts" do
+      json = load_json('contacts.json')
+      net_http_resp = Net::HTTPResponse.new(1.0, 200, 'OK')
 
-			response = RestClient::Response.create(json, net_http_resp, {})
-			RestClient.stub(:get).and_return(response)
-			contacts = @api.get_contacts('token')
-			contact = contacts.results[0]
+      response = RestClient::Response.create(json, net_http_resp, {})
+      RestClient.stub(:get).and_return(response)
+      contacts = @api.get_contacts('token')
+      contact = contacts.results[0]
 
-			contacts.should be_kind_of(ConstantContact::Components::ResultSet)
-			contact.should be_kind_of(ConstantContact::Components::Contact)
-		end
-	end
+      contacts.should be_kind_of(ConstantContact::Components::ResultSet)
+      contact.should be_kind_of(ConstantContact::Components::Contact)
+    end
+  end
 
-	describe "#get_contact" do
-		it "returns a contact" do
-			json = load_json('contact.json')
-			net_http_resp = Net::HTTPResponse.new(1.0, 200, 'OK')
+  describe "#get_contact" do
+    it "returns a contact" do
+      json = load_json('contact.json')
+      net_http_resp = Net::HTTPResponse.new(1.0, 200, 'OK')
 
-			response = RestClient::Response.create(json, net_http_resp, {})
-			RestClient.stub(:get).and_return(response)
-			contact = @api.get_contact('token', 1)
+      response = RestClient::Response.create(json, net_http_resp, {})
+      RestClient.stub(:get).and_return(response)
+      contact = @api.get_contact('token', 1)
 
-			contact.should be_kind_of(ConstantContact::Components::Contact)
-		end
-	end
+      contact.should be_kind_of(ConstantContact::Components::Contact)
+    end
+  end
 
-	describe "#get_contact_by_email" do
-		it "returns a contact" do
-			json = load_json('contacts.json')
-			net_http_resp = Net::HTTPResponse.new(1.0, 200, 'OK')
+  describe "#get_contact_by_email" do
+    it "returns a contact" do
+      json = load_json('contacts.json')
+      net_http_resp = Net::HTTPResponse.new(1.0, 200, 'OK')
 
-			response = RestClient::Response.create(json, net_http_resp, {})
-			RestClient.stub(:get).and_return(response)
-			contacts = @api.get_contact_by_email('token', 'john.smith@gmail.com')
-			contact = contacts.results[0]
+      response = RestClient::Response.create(json, net_http_resp, {})
+      RestClient.stub(:get).and_return(response)
+      contacts = @api.get_contact_by_email('token', 'john.smith@gmail.com')
+      contact = contacts.results[0]
 
-			contact.should be_kind_of(ConstantContact::Components::Contact)
-		end
-	end
+      contact.should be_kind_of(ConstantContact::Components::Contact)
+    end
+  end
 
-	describe "#add_contact" do
-		it "adds a contact" do
-			json = load_json('contact.json')
-			net_http_resp = Net::HTTPResponse.new(1.0, 200, 'OK')
+  describe "#add_contact" do
+    it "adds a contact" do
+      json = load_json('contact.json')
+      net_http_resp = Net::HTTPResponse.new(1.0, 200, 'OK')
 
-			response = RestClient::Response.create(json, net_http_resp, {})
-			RestClient.stub(:post).and_return(response)
-			contact = ConstantContact::Components::Contact.create(JSON.parse(json))
-			added = @api.add_contact('token', contact)
+      response = RestClient::Response.create(json, net_http_resp, {})
+      RestClient.stub(:post).and_return(response)
+      contact = ConstantContact::Components::Contact.create(JSON.parse(json))
+      added = @api.add_contact('token', contact)
 
-			added.should respond_to(:status)
-			added.status.should eq('REMOVED')
-		end
-	end
+      added.should respond_to(:status)
+      added.status.should eq('REMOVED')
+    end
+  end
 
-	describe "#delete_contact" do
-		it "deletes a contact" do
-			json = load_json('contact.json')
-			net_http_resp = Net::HTTPResponse.new(1.0, 204, 'No Content')
+  describe "#delete_contact" do
+    it "deletes a contact" do
+      json = load_json('contact.json')
+      net_http_resp = Net::HTTPResponse.new(1.0, 204, 'No Content')
 
-			response = RestClient::Response.create('', net_http_resp, {})
-			RestClient.stub(:delete).and_return(response)
-			contact = ConstantContact::Components::Contact.create(JSON.parse(json))
-			@api.delete_contact('token', contact).should be_true
-		end
-	end
+      response = RestClient::Response.create('', net_http_resp, {})
+      RestClient.stub(:delete).and_return(response)
+      contact = ConstantContact::Components::Contact.create(JSON.parse(json))
+      @api.delete_contact('token', contact).should be_true
+    end
+  end
 
-	describe "#delete_contact_from_lists" do
-		it "deletes a contact" do
-			json = load_json('contact.json')
-			net_http_resp = Net::HTTPResponse.new(1.0, 204, 'No Content')
+  describe "#delete_contact_from_lists" do
+    it "deletes a contact" do
+      json = load_json('contact.json')
+      net_http_resp = Net::HTTPResponse.new(1.0, 204, 'No Content')
 
-			response = RestClient::Response.create('', net_http_resp, {})
-			RestClient.stub(:delete).and_return(response)
-			contact = ConstantContact::Components::Contact.create(JSON.parse(json))
-			@api.delete_contact_from_lists('token', contact).should be_true
-		end
-	end
+      response = RestClient::Response.create('', net_http_resp, {})
+      RestClient.stub(:delete).and_return(response)
+      contact = ConstantContact::Components::Contact.create(JSON.parse(json))
+      @api.delete_contact_from_lists('token', contact).should be_true
+    end
+  end
 
-	describe "#delete_contact_from_list" do
-		it "deletes a contact" do
-			contact_json = load_json('contact.json')
-			list_json = load_json('list.json')
-			net_http_resp = Net::HTTPResponse.new(1.0, 204, 'No Content')
+  describe "#delete_contact_from_list" do
+    it "deletes a contact" do
+      contact_json = load_json('contact.json')
+      list_json = load_json('list.json')
+      net_http_resp = Net::HTTPResponse.new(1.0, 204, 'No Content')
 
-			response = RestClient::Response.create('', net_http_resp, {})
-			RestClient.stub(:delete).and_return(response)
-			contact = ConstantContact::Components::Contact.create(JSON.parse(contact_json))
-			list = ConstantContact::Components::ContactList.create(JSON.parse(list_json))
-			@api.delete_contact_from_list('token', contact, list).should be_true
-		end
-	end
+      response = RestClient::Response.create('', net_http_resp, {})
+      RestClient.stub(:delete).and_return(response)
+      contact = ConstantContact::Components::Contact.create(JSON.parse(contact_json))
+      list = ConstantContact::Components::ContactList.create(JSON.parse(list_json))
+      @api.delete_contact_from_list('token', contact, list).should be_true
+    end
+  end
 
-	describe "#update_contact" do
-		it "updates a contact" do
-			json = load_json('contact.json')
-			net_http_resp = Net::HTTPResponse.new(1.0, 200, 'OK')
+  describe "#update_contact" do
+    it "updates a contact" do
+      json = load_json('contact.json')
+      net_http_resp = Net::HTTPResponse.new(1.0, 200, 'OK')
 
-			response = RestClient::Response.create(json, net_http_resp, {})
-			RestClient.stub(:put).and_return(response)
-			contact = ConstantContact::Components::Contact.create(JSON.parse(json))
-			added = @api.update_contact('token', contact)
+      response = RestClient::Response.create(json, net_http_resp, {})
+      RestClient.stub(:put).and_return(response)
+      contact = ConstantContact::Components::Contact.create(JSON.parse(json))
+      added = @api.update_contact('token', contact)
 
-			added.should respond_to(:status)
-			added.status.should eq('REMOVED')
-		end
-	end
+      added.should respond_to(:status)
+      added.status.should eq('REMOVED')
+    end
+  end
 
-	describe "#get_lists" do
-		it "returns an array of lists" do
-			json = load_json('lists.json')
-			net_http_resp = Net::HTTPResponse.new(1.0, 200, 'OK')
+  describe "#get_lists" do
+    it "returns an array of lists" do
+      json = load_json('lists.json')
+      net_http_resp = Net::HTTPResponse.new(1.0, 200, 'OK')
 
-			response = RestClient::Response.create(json, net_http_resp, {})
-			RestClient.stub(:get).and_return(response)
-			lists = @api.get_lists('token')
-			list = lists[0]
+      response = RestClient::Response.create(json, net_http_resp, {})
+      RestClient.stub(:get).and_return(response)
+      lists = @api.get_lists('token')
+      list = lists[0]
 
-			lists.should be_kind_of(Array)
-			list.should be_kind_of(ConstantContact::Components::ContactList)
-		end
-	end
+      lists.should be_kind_of(Array)
+      list.should be_kind_of(ConstantContact::Components::ContactList)
+    end
+  end
 
-	describe "#get_list" do
-		it "returns a list" do
-			json = load_json('list.json')
-			net_http_resp = Net::HTTPResponse.new(1.0, 200, 'OK')
+  describe "#get_list" do
+    it "returns a list" do
+      json = load_json('list.json')
+      net_http_resp = Net::HTTPResponse.new(1.0, 200, 'OK')
 
-			response = RestClient::Response.create(json, net_http_resp, {})
-			RestClient.stub(:get).and_return(response)
-			contact = @api.get_list('token', 1)
+      response = RestClient::Response.create(json, net_http_resp, {})
+      RestClient.stub(:get).and_return(response)
+      contact = @api.get_list('token', 1)
 
-			contact.should be_kind_of(ConstantContact::Components::ContactList)
-		end
-	end
+      contact.should be_kind_of(ConstantContact::Components::ContactList)
+    end
+  end
 
-	describe "#add_list" do
-		it "adds a list" do
-			json = load_json('list.json')
-			net_http_resp = Net::HTTPResponse.new(1.0, 200, 'OK')
+  describe "#add_list" do
+    it "adds a list" do
+      json = load_json('list.json')
+      net_http_resp = Net::HTTPResponse.new(1.0, 200, 'OK')
 
-			response = RestClient::Response.create(json, net_http_resp, {})
-			RestClient.stub(:post).and_return(response)
-			list = ConstantContact::Components::ContactList.create(JSON.parse(json))
-			added = @api.add_list('token', list)
+      response = RestClient::Response.create(json, net_http_resp, {})
+      RestClient.stub(:post).and_return(response)
+      list = ConstantContact::Components::ContactList.create(JSON.parse(json))
+      added = @api.add_list('token', list)
 
-			added.should respond_to(:status)
-			added.status.should eq('ACTIVE')
-		end
-	end
+      added.should respond_to(:status)
+      added.status.should eq('ACTIVE')
+    end
+  end
 
-	describe "#get_contacts_from_list" do
-		it "returns an array of contacts" do
-			json_list = load_json('list.json')
-			json_contacts = load_json('contacts.json')
-			net_http_resp = Net::HTTPResponse.new(1.0, 200, 'OK')
+  describe "#get_contacts_from_list" do
+    it "returns an array of contacts" do
+      json_list = load_json('list.json')
+      json_contacts = load_json('contacts.json')
+      net_http_resp = Net::HTTPResponse.new(1.0, 200, 'OK')
 
-			response = RestClient::Response.create(json_contacts, net_http_resp, {})
-			RestClient.stub(:get).and_return(response)
-			list = ConstantContact::Components::ContactList.create(JSON.parse(json_list))
-			contacts = @api.get_contacts_from_list('token', list)
-			contact = contacts.results[0]
+      response = RestClient::Response.create(json_contacts, net_http_resp, {})
+      RestClient.stub(:get).and_return(response)
+      list = ConstantContact::Components::ContactList.create(JSON.parse(json_list))
+      contacts = @api.get_contacts_from_list('token', list)
+      contact = contacts.results[0]
 
-			contacts.should be_kind_of(ConstantContact::Components::ResultSet)
-			contact.should be_kind_of(ConstantContact::Components::Contact)
-		end
-	end
+      contacts.should be_kind_of(ConstantContact::Components::ResultSet)
+      contact.should be_kind_of(ConstantContact::Components::Contact)
+    end
+  end
 end

--- a/spec/constantcontact/auth/oauth2_spec.rb
+++ b/spec/constantcontact/auth/oauth2_spec.rb
@@ -7,42 +7,42 @@
 require 'spec_helper'
 
 describe ConstantContact::Auth::OAuth2 do
-	describe "#new" do
-		it "fails without arguments" do
-			lambda {
-				ConstantContact::Auth::OAuth2.new
-			}.should raise_error(ArgumentError)
-		end
+  describe "#new" do
+    it "fails without arguments" do
+      lambda {
+        ConstantContact::Auth::OAuth2.new
+      }.should raise_error(ArgumentError)
+    end
 
-		it "takes one argument" do
-			opts = {:api_key => 'api key', :api_secret => 'secret', :redirect_url => 'redirect url'}
-			lambda {
-				ConstantContact::Auth::OAuth2.new(opts)
-			}.should_not raise_error(ArgumentError)
-		end
-	end
+    it "takes one argument" do
+      opts = {:api_key => 'api key', :api_secret => 'secret', :redirect_url => 'redirect url'}
+      lambda {
+        ConstantContact::Auth::OAuth2.new(opts)
+      }.should_not raise_error(ArgumentError)
+    end
+  end
 
-	describe "#get_authorization_url" do
-		before(:each) do
-			opts = {:api_key => 'api key', :api_secret => 'secret', :redirect_url => 'redirect url'}
-			@auth = ConstantContact::Auth::OAuth2.new(opts)
-		end
+  describe "#get_authorization_url" do
+    before(:each) do
+      opts = {:api_key => 'api key', :api_secret => 'secret', :redirect_url => 'redirect url'}
+      @auth = ConstantContact::Auth::OAuth2.new(opts)
+    end
 
-		it "returns a string" do
-			@auth.get_authorization_url.should be_kind_of(String)
-		end
-	end
+    it "returns a string" do
+      @auth.get_authorization_url.should be_kind_of(String)
+    end
+  end
 
-	describe "#get_access_token" do
-		before(:each) do
-			opts = {:api_key => 'api key', :api_secret => 'secret', :redirect_url => 'redirect url'}
-			@auth = ConstantContact::Auth::OAuth2.new(opts)
-		end
+  describe "#get_access_token" do
+    before(:each) do
+      opts = {:api_key => 'api key', :api_secret => 'secret', :redirect_url => 'redirect url'}
+      @auth = ConstantContact::Auth::OAuth2.new(opts)
+    end
 
-		it "returns a Hash" do
-			json = load_json('access_token.json')
-			RestClient.stub(:post).and_return(json)
-			@auth.get_access_token('token').should be_kind_of(Hash)
-		end
-	end
+    it "returns a Hash" do
+      json = load_json('access_token.json')
+      RestClient.stub(:post).and_return(json)
+      @auth.get_access_token('token').should be_kind_of(Hash)
+    end
+  end
 end

--- a/spec/constantcontact/components/contacts/address_spec.rb
+++ b/spec/constantcontact/components/contacts/address_spec.rb
@@ -7,12 +7,12 @@
 require 'spec_helper'
 
 describe ConstantContact::Components::Address do
-	describe "#from_list" do
-		it "should return an address" do
-			json = load_json('address.json')
-			address = ConstantContact::Components::Address.create(JSON.parse(json))
+  describe "#from_list" do
+    it "should return an address" do
+      json = load_json('address.json')
+      address = ConstantContact::Components::Address.create(JSON.parse(json))
 
-			address.line1.should eq('6 Main Street')
-		end
-	end
+      address.line1.should eq('6 Main Street')
+    end
+  end
 end

--- a/spec/constantcontact/components/contacts/contact_list_spec.rb
+++ b/spec/constantcontact/components/contacts/contact_list_spec.rb
@@ -7,12 +7,12 @@
 require 'spec_helper'
 
 describe ConstantContact::Components::ContactList do
-	describe "#from_list" do
-		it "should return a list" do
-			json = load_json('list.json')
-			list = ConstantContact::Components::ContactList.create(JSON.parse(json))
+  describe "#from_list" do
+    it "should return a list" do
+      json = load_json('list.json')
+      list = ConstantContact::Components::ContactList.create(JSON.parse(json))
 
-			list.name.should eq('Fake List')
-		end
-	end
+      list.name.should eq('Fake List')
+    end
+  end
 end

--- a/spec/constantcontact/components/contacts/contact_spec.rb
+++ b/spec/constantcontact/components/contacts/contact_spec.rb
@@ -7,12 +7,12 @@
 require 'spec_helper'
 
 describe ConstantContact::Components::Contact do
-	describe "#from_list" do
-		it "should return a contact" do
-			json = load_json('contact.json')
-			contact = ConstantContact::Components::Contact.create(JSON.parse(json))
+  describe "#from_list" do
+    it "should return a contact" do
+      json = load_json('contact.json')
+      contact = ConstantContact::Components::Contact.create(JSON.parse(json))
 
-			contact.last_name.should eq('Smith')
-		end
-	end
+      contact.last_name.should eq('Smith')
+    end
+  end
 end

--- a/spec/constantcontact/components/contacts/custom_field_spec.rb
+++ b/spec/constantcontact/components/contacts/custom_field_spec.rb
@@ -7,12 +7,12 @@
 require 'spec_helper'
 
 describe ConstantContact::Components::CustomField do
-	describe "#from_list" do
-		it "should return a custom field" do
-			json = '{"name":"Property", "value":"Private"}'
-			field = ConstantContact::Components::CustomField.create(JSON.parse(json))
+  describe "#from_list" do
+    it "should return a custom field" do
+      json = '{"name":"Property", "value":"Private"}'
+      field = ConstantContact::Components::CustomField.create(JSON.parse(json))
 
-			field.name.should eq('Property')
-		end
-	end
+      field.name.should eq('Property')
+    end
+  end
 end

--- a/spec/constantcontact/components/contacts/email_address_spec.rb
+++ b/spec/constantcontact/components/contacts/email_address_spec.rb
@@ -7,12 +7,12 @@
 require 'spec_helper'
 
 describe ConstantContact::Components::EmailAddress do
-	describe "#from_list" do
-		it "should return an email address" do
-			json = load_json('email_address.json')
-			email = ConstantContact::Components::EmailAddress.create(JSON.parse(json))
+  describe "#from_list" do
+    it "should return an email address" do
+      json = load_json('email_address.json')
+      email = ConstantContact::Components::EmailAddress.create(JSON.parse(json))
 
-			email.email_address.should eq('wm2q7rwtp77m@roving.com')
-		end
-	end
+      email.email_address.should eq('wm2q7rwtp77m@roving.com')
+    end
+  end
 end

--- a/spec/constantcontact/services/contact_service_spec.rb
+++ b/spec/constantcontact/services/contact_service_spec.rb
@@ -7,99 +7,99 @@
 require 'spec_helper'
 
 describe ConstantContact::Services::ContactService do
-	describe "#get_contacts" do
-		it "returns an array of contacts" do
-			json = load_json('contacts.json')
-			net_http_resp = Net::HTTPResponse.new(1.0, 200, 'OK')
+  describe "#get_contacts" do
+    it "returns an array of contacts" do
+      json = load_json('contacts.json')
+      net_http_resp = Net::HTTPResponse.new(1.0, 200, 'OK')
 
-			response = RestClient::Response.create(json, net_http_resp, {})
-			RestClient.stub(:get).and_return(response)
-			contacts = ConstantContact::Services::ContactService.get_contacts('token')
-			contact = contacts.results[0]
+      response = RestClient::Response.create(json, net_http_resp, {})
+      RestClient.stub(:get).and_return(response)
+      contacts = ConstantContact::Services::ContactService.get_contacts('token')
+      contact = contacts.results[0]
 
-			contacts.should be_kind_of(ConstantContact::Components::ResultSet)
-			contact.should be_kind_of(ConstantContact::Components::Contact)
-		end
-	end
+      contacts.should be_kind_of(ConstantContact::Components::ResultSet)
+      contact.should be_kind_of(ConstantContact::Components::Contact)
+    end
+  end
 
-	describe "#get_contact" do
-		it "returns a contact" do
-			json = load_json('contact.json')
-			net_http_resp = Net::HTTPResponse.new(1.0, 200, 'OK')
+  describe "#get_contact" do
+    it "returns a contact" do
+      json = load_json('contact.json')
+      net_http_resp = Net::HTTPResponse.new(1.0, 200, 'OK')
 
-			response = RestClient::Response.create(json, net_http_resp, {})
-			RestClient.stub(:get).and_return(response)
-			contact = ConstantContact::Services::ContactService.get_contact('token', 1)
+      response = RestClient::Response.create(json, net_http_resp, {})
+      RestClient.stub(:get).and_return(response)
+      contact = ConstantContact::Services::ContactService.get_contact('token', 1)
 
-			contact.should be_kind_of(ConstantContact::Components::Contact)
-		end
-	end
+      contact.should be_kind_of(ConstantContact::Components::Contact)
+    end
+  end
 
-	describe "#add_contact" do
-		it "adds a contact" do
-			json = load_json('contact.json')
-			net_http_resp = Net::HTTPResponse.new(1.0, 200, 'OK')
+  describe "#add_contact" do
+    it "adds a contact" do
+      json = load_json('contact.json')
+      net_http_resp = Net::HTTPResponse.new(1.0, 200, 'OK')
 
-			response = RestClient::Response.create(json, net_http_resp, {})
-			RestClient.stub(:post).and_return(response)
-			contact = ConstantContact::Components::Contact.create(JSON.parse(json))
-			added = ConstantContact::Services::ContactService.add_contact('token', contact)
+      response = RestClient::Response.create(json, net_http_resp, {})
+      RestClient.stub(:post).and_return(response)
+      contact = ConstantContact::Components::Contact.create(JSON.parse(json))
+      added = ConstantContact::Services::ContactService.add_contact('token', contact)
 
-			added.should respond_to(:status)
-			added.status.should eq('REMOVED')
-		end
-	end
+      added.should respond_to(:status)
+      added.status.should eq('REMOVED')
+    end
+  end
 
-	describe "#delete_contact" do
-		it "deletes a contact" do
-			json = load_json('contact.json')
-			net_http_resp = Net::HTTPResponse.new(1.0, 204, 'No Content')
+  describe "#delete_contact" do
+    it "deletes a contact" do
+      json = load_json('contact.json')
+      net_http_resp = Net::HTTPResponse.new(1.0, 204, 'No Content')
 
-			response = RestClient::Response.create('', net_http_resp, {})
-			RestClient.stub(:delete).and_return(response)
-			contact = ConstantContact::Components::Contact.create(JSON.parse(json))
-			ConstantContact::Services::ContactService.delete_contact('token', contact).should be_true
-		end
-	end
+      response = RestClient::Response.create('', net_http_resp, {})
+      RestClient.stub(:delete).and_return(response)
+      contact = ConstantContact::Components::Contact.create(JSON.parse(json))
+      ConstantContact::Services::ContactService.delete_contact('token', contact).should be_true
+    end
+  end
 
-	describe "#delete_contact_from_lists" do
-		it "deletes a contact" do
-			json = load_json('contact.json')
-			net_http_resp = Net::HTTPResponse.new(1.0, 204, 'No Content')
+  describe "#delete_contact_from_lists" do
+    it "deletes a contact" do
+      json = load_json('contact.json')
+      net_http_resp = Net::HTTPResponse.new(1.0, 204, 'No Content')
 
-			response = RestClient::Response.create('', net_http_resp, {})
-			RestClient.stub(:delete).and_return(response)
-			contact = ConstantContact::Components::Contact.create(JSON.parse(json))
-			ConstantContact::Services::ContactService.delete_contact_from_lists('token', contact).should be_true
-		end
-	end
+      response = RestClient::Response.create('', net_http_resp, {})
+      RestClient.stub(:delete).and_return(response)
+      contact = ConstantContact::Components::Contact.create(JSON.parse(json))
+      ConstantContact::Services::ContactService.delete_contact_from_lists('token', contact).should be_true
+    end
+  end
 
-	describe "#delete_contact_from_list" do
-		it "deletes a contact" do
-			contact_json = load_json('contact.json')
-			list_json = load_json('list.json')
-			net_http_resp = Net::HTTPResponse.new(1.0, 204, 'No Content')
+  describe "#delete_contact_from_list" do
+    it "deletes a contact" do
+      contact_json = load_json('contact.json')
+      list_json = load_json('list.json')
+      net_http_resp = Net::HTTPResponse.new(1.0, 204, 'No Content')
 
-			response = RestClient::Response.create('', net_http_resp, {})
-			RestClient.stub(:delete).and_return(response)
-			contact = ConstantContact::Components::Contact.create(JSON.parse(contact_json))
-			list = ConstantContact::Components::ContactList.create(JSON.parse(list_json))
-			ConstantContact::Services::ContactService.delete_contact_from_list('token', contact, list).should be_true
-		end
-	end
+      response = RestClient::Response.create('', net_http_resp, {})
+      RestClient.stub(:delete).and_return(response)
+      contact = ConstantContact::Components::Contact.create(JSON.parse(contact_json))
+      list = ConstantContact::Components::ContactList.create(JSON.parse(list_json))
+      ConstantContact::Services::ContactService.delete_contact_from_list('token', contact, list).should be_true
+    end
+  end
 
-	describe "#update_contact" do
-		it "updates a contact" do
-			json = load_json('contact.json')
-			net_http_resp = Net::HTTPResponse.new(1.0, 200, 'OK')
+  describe "#update_contact" do
+    it "updates a contact" do
+      json = load_json('contact.json')
+      net_http_resp = Net::HTTPResponse.new(1.0, 200, 'OK')
 
-			response = RestClient::Response.create(json, net_http_resp, {})
-			RestClient.stub(:put).and_return(response)
-			contact = ConstantContact::Components::Contact.create(JSON.parse(json))
-			added = ConstantContact::Services::ContactService.update_contact('token', contact)
+      response = RestClient::Response.create(json, net_http_resp, {})
+      RestClient.stub(:put).and_return(response)
+      contact = ConstantContact::Components::Contact.create(JSON.parse(json))
+      added = ConstantContact::Services::ContactService.update_contact('token', contact)
 
-			added.should respond_to(:status)
-			added.status.should eq('REMOVED')
-		end
-	end
+      added.should respond_to(:status)
+      added.status.should eq('REMOVED')
+    end
+  end
 end

--- a/spec/constantcontact/services/list_service_spec.rb
+++ b/spec/constantcontact/services/list_service_spec.rb
@@ -7,63 +7,63 @@
 require 'spec_helper'
 
 describe ConstantContact::Services::ListService do
-	describe "#get_lists" do
-		it "returns an array of lists" do
-			json = load_json('lists.json')
-			net_http_resp = Net::HTTPResponse.new(1.0, 200, 'OK')
+  describe "#get_lists" do
+    it "returns an array of lists" do
+      json = load_json('lists.json')
+      net_http_resp = Net::HTTPResponse.new(1.0, 200, 'OK')
 
-			response = RestClient::Response.create(json, net_http_resp, {})
-			RestClient.stub(:get).and_return(response)
-			lists = ConstantContact::Services::ListService.get_lists('token')
-			list = lists[0]
+      response = RestClient::Response.create(json, net_http_resp, {})
+      RestClient.stub(:get).and_return(response)
+      lists = ConstantContact::Services::ListService.get_lists('token')
+      list = lists[0]
 
-			lists.should be_kind_of(Array)
-			list.should be_kind_of(ConstantContact::Components::ContactList)
-		end
-	end
+      lists.should be_kind_of(Array)
+      list.should be_kind_of(ConstantContact::Components::ContactList)
+    end
+  end
 
-	describe "#get_list" do
-		it "returns a list" do
-			json = load_json('list.json')
-			net_http_resp = Net::HTTPResponse.new(1.0, 200, 'OK')
+  describe "#get_list" do
+    it "returns a list" do
+      json = load_json('list.json')
+      net_http_resp = Net::HTTPResponse.new(1.0, 200, 'OK')
 
-			response = RestClient::Response.create(json, net_http_resp, {})
-			RestClient.stub(:get).and_return(response)
-			contact = ConstantContact::Services::ListService.get_list('token', 1)
+      response = RestClient::Response.create(json, net_http_resp, {})
+      RestClient.stub(:get).and_return(response)
+      contact = ConstantContact::Services::ListService.get_list('token', 1)
 
-			contact.should be_kind_of(ConstantContact::Components::ContactList)
-		end
-	end
+      contact.should be_kind_of(ConstantContact::Components::ContactList)
+    end
+  end
 
-	describe "#add_list" do
-		it "adds a list" do
-			json = load_json('list.json')
-			net_http_resp = Net::HTTPResponse.new(1.0, 200, 'OK')
+  describe "#add_list" do
+    it "adds a list" do
+      json = load_json('list.json')
+      net_http_resp = Net::HTTPResponse.new(1.0, 200, 'OK')
 
-			response = RestClient::Response.create(json, net_http_resp, {})
-			RestClient.stub(:post).and_return(response)
-			list = ConstantContact::Components::ContactList.create(JSON.parse(json))
-			added = ConstantContact::Services::ListService.add_list('token', list)
+      response = RestClient::Response.create(json, net_http_resp, {})
+      RestClient.stub(:post).and_return(response)
+      list = ConstantContact::Components::ContactList.create(JSON.parse(json))
+      added = ConstantContact::Services::ListService.add_list('token', list)
 
-			added.should respond_to(:status)
-			added.status.should eq('ACTIVE')
-		end
-	end
+      added.should respond_to(:status)
+      added.status.should eq('ACTIVE')
+    end
+  end
 
-	describe "#get_contacts_from_list" do
-		it "returns an array of contacts" do
-			json_list = load_json('list.json')
-			json_contacts = load_json('contacts.json')
-			net_http_resp = Net::HTTPResponse.new(1.0, 200, 'OK')
+  describe "#get_contacts_from_list" do
+    it "returns an array of contacts" do
+      json_list = load_json('list.json')
+      json_contacts = load_json('contacts.json')
+      net_http_resp = Net::HTTPResponse.new(1.0, 200, 'OK')
 
-			response = RestClient::Response.create(json_contacts, net_http_resp, {})
-			RestClient.stub(:get).and_return(response)
-			list = ConstantContact::Components::ContactList.create(JSON.parse(json_list))
-			contacts = ConstantContact::Services::ListService.get_contacts_from_list('token', list)
-			contact = contacts.results[0]
+      response = RestClient::Response.create(json_contacts, net_http_resp, {})
+      RestClient.stub(:get).and_return(response)
+      list = ConstantContact::Components::ContactList.create(JSON.parse(json_list))
+      contacts = ConstantContact::Services::ListService.get_contacts_from_list('token', list)
+      contact = contacts.results[0]
 
-			contacts.should be_kind_of(ConstantContact::Components::ResultSet)
-			contact.should be_kind_of(ConstantContact::Components::Contact)
-		end
-	end
+      contacts.should be_kind_of(ConstantContact::Components::ResultSet)
+      contact.should be_kind_of(ConstantContact::Components::Contact)
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,5 +9,5 @@ require 'constantcontact'
 
 
 def load_json(file_name)
-	json = File.read(File.join(File.dirname(__FILE__), 'fixtures', file_name))
+  json = File.read(File.join(File.dirname(__FILE__), 'fixtures', file_name))
 end


### PR DESCRIPTION
Currently all the ruby files have odd tabbing in the files that makes them hard to read when browsed on Github.  I've converted all the tabs to spaces so the code is a bit easier to read.

All tests still pass when ran.
### Before

![Before](http://cl.ly/image/3K1l0X1f0W0l/Screen%20Shot%202013-04-09%20at%2011.51.56%20AM.png)
### After

![After](http://cl.ly/image/0M3w1U151D0L/Screen%20Shot%202013-04-09%20at%2011.51.38%20AM.png)
