### PR TITLE
Fix md formatting for Sinatra example

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ B. Sinatra example :
         gem install constantcontact
 
 2. Add the following code in myapp.rb (just an example):
+
         require 'active_support'
         require 'constantcontact'
 


### PR DESCRIPTION
The require statements:

```
require 'active_support'
require 'constantcontact'
```

weren't formatting as part of the Sinatra example code block. Added a missing line break fixes the formatting.
