### PR TITLE
Add modified date to note

### DIFF
--- a/lib/constantcontact/components/contacts/note.rb
+++ b/lib/constantcontact/components/contacts/note.rb
@@ -7,7 +7,7 @@
 module ConstantContact
   module Components
     class Note < Component
-      attr_accessor :id, :note, :created_date
+      attr_accessor :id, :note, :created_date, :modified_date
 
       # Factory method to create a Note object from a json string
       # @param [String] props - properties to create object from


### PR DESCRIPTION
Its in the api spec, see:
http://developer.constantcontact.com/docs/contacts-api/contacts-collection.html

Attempts to use notes will fail without it with undefined method
modified_date for note
