### PR TITLE
before parsing to JSON we should check data exists

### DIFF
--- a/lib/constantcontact/auth/oauth2.rb
+++ b/lib/constantcontact/auth/oauth2.rb
@@ -71,7 +71,7 @@ module ConstantContact
           response = RestClient.post(url, params)
           response_body = JSON.parse(response)
         rescue => e
-          response_body = e.respond_to?(:response) ?
+          response_body = e.respond_to?(:response) && e.response ?
             JSON.parse(e.response) :
             {'error' => '', 'error_description' => e.message}
         end


### PR DESCRIPTION
We got ssl problem in ruby in one computer and RestClient returned Exception which responded to response but it was nil (what is logical).As JSON.parse cannot parse nil (not a json object) script failed on rescue and we got bad response message. Having this check helped to find a problem