### PR TITLE
extend api for /emailmarketing/campaigns/:campaignId/preview

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,6 @@ PATH
   specs:
     constantcontact (2.0.1)
       json (~> 1.8, >= 1.8.1)
-      mime-types (~> 2.4, >= 2.4.1)
       rest-client (~> 1.6, >= 1.6.7)
 
 GEM
@@ -14,8 +13,8 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     http-cookie (1.0.2)
       domain_name (~> 0.5)
-    json (1.8.2)
-    mime-types (2.4.3)
+    json (1.8.3)
+    mime-types (2.6.1)
     netrc (0.10.3)
     rake (10.1.1)
     rest-client (1.8.0)
@@ -31,6 +30,8 @@ GEM
       diff-lcs (>= 1.1.3, < 2.0)
     rspec-mocks (2.14.4)
     unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.1)
 
 PLATFORMS
   ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    constantcontact (2.0.1)
+    constantcontact (2.0.1.1)
       json (~> 1.8, >= 1.8.1)
       rest-client (~> 1.6, >= 1.6.7)
 

--- a/constantcontact.gemspec
+++ b/constantcontact.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |s|
   s.name = "constantcontact"
-  s.version = '2.0.1'
+  s.version = '2.0.1.1'
   s.platform = Gem::Platform::RUBY
   s.authors = ["ConstantContact"]
   s.homepage = "http://www.constantcontact.com"
@@ -23,9 +23,8 @@ Gem::Specification.new do |s|
   s.executables = []
   s.require_paths = [ "lib" ]
   s.test_files = Dir['spec/**/*_spec.rb']
-  
+
   s.add_runtime_dependency("rest-client", '~> 1.6', '>= 1.6.7')
   s.add_runtime_dependency("json", '~> 1.8', '>= 1.8.1')
-  s.add_runtime_dependency('mime-types', '~> 2.4', '>= 2.4.1')
   s.add_development_dependency("rspec", '~> 2.14')
 end

--- a/lib/constantcontact/api.rb
+++ b/lib/constantcontact/api.rb
@@ -191,6 +191,14 @@ module ConstantContact
     end
 
 
+    # Get an individual campaign's preview
+    # @param [Integer] campaign_id - Valid campaign id
+    # @return [Campaign]
+    def get_email_campaign_preview(campaign_id)
+      Services::EmailMarketingService.get_campaign_preview(campaign_id)
+    end
+
+
     # Delete an individual campaign
     # @param [Mixed] campaign - Id of a campaign or a Campaign object
     # @raise IllegalArgumentException - if a Campaign object or campaign id is not passed
@@ -910,12 +918,12 @@ module ConstantContact
     # Adds a new MyLibrary file using the multipart content-type
     # @param [String] file_name - The name of the file (ie: dinnerplate-special.jpg)
     # @param [String] folder_id - Folder id to add the file to
-    # @param [String] description - The description of the file provided by user 
-    # @param [String] source - indicates the source of the original file; 
+    # @param [String] description - The description of the file provided by user
+    # @param [String] source - indicates the source of the original file;
     #                          image files can be uploaded from the following sources :
     #                          MyComputer, StockImage, Facebook - MyLibrary Plus customers only,
     #                          Instagram - MyLibrary Plus customers only, Shutterstock, Mobile
-    # @param [String] file_type - Specifies the file type, valid values are: JPEG, JPG, GIF, PDF, PNG 
+    # @param [String] file_type - Specifies the file type, valid values are: JPEG, JPG, GIF, PDF, PNG
     # @param [String] contents - The content of the file
     # @return [LibraryFile]
     def add_library_file(file_name, folder_id, description, source, file_type, contents)
@@ -932,7 +940,7 @@ module ConstantContact
 
 
     # Delete one or more MyLibrary files specified by the fileId path parameter;
-    # separate multiple file IDs with a comma. 
+    # separate multiple file IDs with a comma.
     # Deleted files are moved from their current folder into the system Trash folder, and its status is set to Deleted.
     # @param [String] file_id - Specifies the MyLibrary file to delete
     # @return [Boolean]
@@ -941,7 +949,7 @@ module ConstantContact
     end
 
 
-    # Retrieve the upload status for one or more MyLibrary files using the file_id path parameter; 
+    # Retrieve the upload status for one or more MyLibrary files using the file_id path parameter;
     # separate multiple file IDs with a comma
     # @param [String] file_id - Specifies the files for which to retrieve upload status information
     # @return [Array<UploadStatus>]

--- a/lib/constantcontact/services/email_marketing_service.rb
+++ b/lib/constantcontact/services/email_marketing_service.rb
@@ -51,6 +51,21 @@ module ConstantContact
           Components::Campaign.create(JSON.parse(response.body))
         end
 
+        # Get campaign email content for a specific campaign
+        # @param [Integer] campaign_id - Valid campaign id
+        # @return [Campaign]
+        def get_campaign_preview(campaign_id)
+          url = Util::Config.get('endpoints.base_url') +
+                sprintf(Util::Config.get('endpoints.campaign_preview'), campaign_id)
+          url = build_url(url)
+          response = RestClient.get(url, get_headers())
+          data = JSON.parse(response.body)
+          campaign = Components::Campaign.create(data)
+          campaign.email_content = data['preview_email_content']
+          campaign.text_content = data['preview_text_content']
+          campaign
+        end
+
 
         # Delete an email campaign
         # @param [Integer] campaign_id - Valid campaign id

--- a/lib/constantcontact/util/config.rb
+++ b/lib/constantcontact/util/config.rb
@@ -35,6 +35,7 @@ module ConstantContact
 
           :campaigns                      => 'emailmarketing/campaigns',
           :campaign                       => 'emailmarketing/campaigns/%s',
+          :campaign_preview               => 'emailmarketing/campaigns/%s/preview',
           :campaign_schedules             => 'emailmarketing/campaigns/%s/schedules',
           :campaign_schedule              => 'emailmarketing/campaigns/%s/schedules/%s',
           :campaign_test_sends            => 'emailmarketing/campaigns/%s/tests',
@@ -143,7 +144,7 @@ module ConstantContact
       class << self
         attr_accessor :props
 
-         def configure 
+         def configure
           yield props if block_given?
         end
 

--- a/spec/constantcontact/api_spec.rb
+++ b/spec/constantcontact/api_spec.rb
@@ -17,13 +17,13 @@ describe ConstantContact::Api do
   end
 
   it "without api_key defined" do
-    lambda { 
+    lambda {
       ConstantContact::Api.new
     }.should raise_error(ArgumentError, ConstantContact::Util::Config.get('errors.api_key_missing'))
   end
 
   it "without access_token defined" do
-    lambda { 
+    lambda {
       ConstantContact::Api.new('api_key')
     }.should raise_error(ArgumentError, ConstantContact::Util::Config.get('errors.access_token_missing'))
   end
@@ -296,7 +296,7 @@ describe ConstantContact::Api do
         net_http_resp = Net::HTTPResponse.new(1.0, 200, 'OK')
         response = RestClient::Response.create(json, net_http_resp, {}, @request)
         RestClient.stub(:get).and_return(response)
-        
+
         events = @api.get_events()
         events.should be_kind_of(ConstantContact::Components::ResultSet)
         events.results.collect{|e| e.should be_kind_of(ConstantContact::Components::Event) }
@@ -724,6 +724,20 @@ describe ConstantContact::Api do
         RestClient.stub(:get).and_return(response)
 
         campaign = @api.get_email_campaign(1)
+        campaign.should be_kind_of(ConstantContact::Components::Campaign)
+        campaign.name.should eq('Campaign Name')
+      end
+    end
+
+    describe "#get_email_campaign_preview" do
+      it "gets an individual campaign's preview" do
+        json_response = load_file('email_campaign_response.json')
+        net_http_resp = Net::HTTPResponse.new(1.0, 200, 'OK')
+
+        response = RestClient::Response.create(json_response, net_http_resp, {}, @request)
+        RestClient.stub(:get).and_return(response)
+
+        campaign = @api.get_email_campaign_preview(1)
         campaign.should be_kind_of(ConstantContact::Components::Campaign)
         campaign.name.should eq('Campaign Name')
       end

--- a/spec/constantcontact/services/email_marketing_spec.rb
+++ b/spec/constantcontact/services/email_marketing_spec.rb
@@ -40,6 +40,22 @@ describe ConstantContact::Services::EmailMarketingService do
     end
   end
 
+  describe "#get_campaign_preview" do
+    it "returns a campaign preview" do
+      json_response = load_file('email_campaign_preview_response.json')
+      net_http_resp = Net::HTTPResponse.new(1.0, 200, 'OK')
+
+      response = RestClient::Response.create(json_response, net_http_resp, {}, @request)
+      RestClient.stub(:get).and_return(response)
+
+      campaign = ConstantContact::Services::EmailMarketingService.get_campaign_preview(1)
+      campaign.should be_kind_of(ConstantContact::Components::Campaign)
+      campaign.subject.should eq('Example subject line')
+      campaign.email_content.should eq('<body><p>This is text of the email message.</p></body>')
+      campaign.text_content.should eq('This is the text of the email message.')
+    end
+  end
+
   describe "#add_campaign" do
     it "adds a campaign" do
       json = load_file('email_campaign_response.json')

--- a/spec/fixtures/email_campaign_preview_response.json
+++ b/spec/fixtures/email_campaign_preview_response.json
@@ -1,0 +1,7 @@
+{
+  "subject": "Example subject line",
+  "from_email": "fromemail@example.com",
+  "reply_to_email": "replytoemail@example.com",
+  "preview_email_content": "<body><p>This is text of the email message.</p></body>",
+  "preview_text_content": "This is the text of the email message."
+}


### PR DESCRIPTION
This PR does a couple things. The main thing is it adds support for the aforementioned endpoint to match the current Constant Contact API spec. Secondly, it remove the absurdly high version requirement for the mime type gem. The latter was to help support Ruby 4.0+ which version 2.0.1 currently does not due to the mime type requirement. I added specs for the new endpoints and upped the subversion of the gem to meet the new standards.
