### PR TITLE
relax and change dependencies to be compatible with rails 5

### DIFF
--- a/constantcontact.gemspec
+++ b/constantcontact.gemspec
@@ -23,9 +23,9 @@ Gem::Specification.new do |s|
   s.executables = []
   s.require_paths = [ "lib" ]
   s.test_files = Dir['spec/**/*_spec.rb']
-  
-  s.add_runtime_dependency("rest-client", '~> 1.6', '>= 1.6.7')
+
+  s.add_runtime_dependency("rest-client", '~> 1.8')
   s.add_runtime_dependency("json", '~> 1.8', '>= 1.8.1')
-  s.add_runtime_dependency('mime-types', '~> 2.4', '>= 2.4.1')
+  s.add_runtime_dependency('mime-types', '~> 2.99')
   s.add_development_dependency("rspec", '~> 2.14')
 end


### PR DESCRIPTION
Hi,

We recently had to use constant contact with Rails5 and were running to some compatibility problems. As such, I've changed some of the dependency versions in the gemspec and re-ran all the specs.

Everything seems to be passing - and we are successfully using the gem in the project now. I was hoping you could take a quick look and ensure this is alright? If so perhaps we could merge it?

Thanks
